### PR TITLE
Update default host

### DIFF
--- a/lib/posthog/defaults.rb
+++ b/lib/posthog/defaults.rb
@@ -1,7 +1,7 @@
 class PostHog
   module Defaults
     module Request
-      HOST = 't.posthog.com'
+      HOST = 'app.posthog.com'
       PORT = 443
       PATH = '/batch/'
       SSL = true


### PR DESCRIPTION
Even though @fuziontech now made sure t.posthog.com works, I guess it makes sense to keep this consistent with other libs and use app.posthog.com?﻿
