### PR TITLE
Add ability to disable SSL verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+- Add ability to disable SSL verification by passing `skip_ssl_verification`
+
+# 1.2.1 - 2021-11-19
+
+- Add concurrent-ruby gem dependency (fixes #8)
+
 # 1.1.0 - 2020-12-15
 
 - Change default domain from `t.posthog.com` to `app.posthog.com`

--- a/lib/posthog/transport.rb
+++ b/lib/posthog/transport.rb
@@ -32,6 +32,9 @@ class PostHog
       http.use_ssl = options[:ssl]
       http.read_timeout = 8
       http.open_timeout = 4
+      if options[:skip_ssl_verification]
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      end
 
       @http = http
     end

--- a/lib/posthog/worker.rb
+++ b/lib/posthog/worker.rb
@@ -28,7 +28,7 @@ class PostHog
       batch_size = options[:batch_size] || Defaults::MessageBatch::MAX_SIZE
       @batch = MessageBatch.new(batch_size)
       @lock = Mutex.new
-      @transport = Transport.new api_host: options[:api_host]
+      @transport = Transport.new api_host: options[:api_host], skip_ssl_verification: options[:skip_ssl_verification]
     end
 
     # public: Continuously runs the loop to check for new events

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -24,6 +24,11 @@ class PostHog
       it 'does not error if a api_key is supplied as a string' do
         expect { Client.new 'api_key' => API_KEY }.to_not raise_error
       end
+
+      it 'handles skip_ssl_verification' do
+        expect(PostHog::Transport).to receive(:new).with({api_host: nil, skip_ssl_verification: true})
+        expect { Client.new api_key: API_KEY, skip_ssl_verification: true }.to_not raise_error
+      end
     end
 
     describe '#capture' do

--- a/spec/posthog/transport_spec.rb
+++ b/spec/posthog/transport_spec.rb
@@ -48,6 +48,11 @@ class PostHog
           expect(backoff_policy).to be_a(PostHog::BackoffPolicy)
         end
 
+        it 'uses the default verify mode' do
+          expect(net_http).to_not receive(:verify_mode=)
+          described_class.new
+        end
+
         it 'initializes a new Net::HTTP with default host and port' do
           expect(Net::HTTP).to receive(:new).with(
             described_class::HOST,
@@ -61,6 +66,7 @@ class PostHog
         let(:path) { 'my/cool/path' }
         let(:retries) { 1234 }
         let(:backoff_policy) { FakeBackoffPolicy.new([1, 2, 3]) }
+        let(:skip_ssl_verification) { true }
         let(:host) { 'http://www.example.com' }
         let(:port) { 8080 }
         let(:options) do
@@ -68,6 +74,7 @@ class PostHog
             path: path,
             retries: retries,
             backoff_policy: backoff_policy,
+            skip_ssl_verification: skip_ssl_verification,
             host: host,
             port: port
           }
@@ -87,6 +94,11 @@ class PostHog
           expect(subject.instance_variable_get(:@backoff_policy)).to eq(
             backoff_policy
           )
+        end
+
+        it 'skips SSL verification if passed' do
+          expect(net_http).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
+          described_class.new(options)
         end
 
         it 'initializes a new Net::HTTP with passed in host and port' do


### PR DESCRIPTION
Use case: we have a staging environment with its own PostHog instance. It's not exposed to the internet, and uses a self-signed SSL certificate. This staging instance is useful for development. We currently need to manually change `transport.rb` to disable SSL verification, otherwise posthog-ruby's requests fail.

This PR makes it easier to use PostHog behind a self-signed SSL certificate by passing in an option to `PostHog::Client.new`. This will also allow us to send events from our staging Ruby app.

This is maybe a pretty niche requirement, so understandable if you don't want to merge it, but it'd be useful for us! I've tested these modifications with our Ruby app and it works.