### PR TITLE
present? is not available outside of Rails

### DIFF
--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -31,7 +31,7 @@ class PostHog
 
       check_api_key!
 
-      if opts[:personal_api_key].present?
+      if opts[:personal_api_key]
         @personal_api_key = opts[:personal_api_key]
         @feature_flags_poller =
           FeatureFlagsPoller.new(


### PR DESCRIPTION
Hey guys! Just a headsup -- `present?` is not available outside of Rails. This causes client creation to fail with `undefined method .present? for nil::nilClass`.