### PR TITLE
Fix posthog.alias call

### DIFF
--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -54,7 +54,7 @@ class PostHog
       def parse_for_alias(fields)
         common = parse_common_fields(fields)
 
-        distinct_id = common[:distinct_id] # must move to properties...
+        distinct_id = common[:distinct_id] # must both be set and move to properties
 
         alias_field = fields[:alias]
         check_presence! alias_field, 'alias'
@@ -63,7 +63,7 @@ class PostHog
           {
             type: 'alias',
             event: '$create_alias',
-            distinct_id: nil,
+            distinct_id: distinct_id,
             properties:
               { distinct_id: distinct_id, alias: alias_field }.merge(
                 common[:properties] || {}

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -174,6 +174,28 @@ class PostHog
       it 'does not error with the required options as strings' do
         expect { client.alias Utils.stringify_keys(ALIAS) }.to_not raise_error
       end
+
+      it 'sets distinct_id property' do
+        client.alias(
+          {
+            distinct_id: 'old_user',
+            alias: 'new_user'
+          }
+        )
+
+        message = queue.pop
+        expect(message).to include(
+          {
+            type: 'alias',
+            distinct_id: 'old_user',
+            event: "$create_alias"
+          }
+        )
+        expect(message[:properties]).to include(
+          distinct_id: 'old_user',
+          alias: 'new_user'
+        )
+      end
     end
 
     describe '#flush' do


### PR DESCRIPTION
Fixes https://github.com/PostHog/posthog-ruby/issues/13

We were rejecting calls for this before as distinct_id has been mandatory for some time.