### PR TITLE
Enable local evaluation of feature flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ coverage/
 .bundle
 vendor/bundle
 .idea
+.ruby-version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Breaking changes:
 1. Minimum PostHog version requirement: 1.38
 2. Regular feature flag evaluation (i.e. by requesting from your PostHog servers) doesn't require a personal API key.
 3. `Client` initialisation doesn't take the `api_host` parameter anymore. Instead, it takes the `host` parameter, which needs to be fully qualified. For example: `https://api.posthog.com` is valid, while `api.posthog.com` is not valid.
-4. The log level by default is set to INFO. You can change it to DEBUG if you want to debug the client by running `client.logger.level = Logger::INFO`, where client is your initialized `PostHog::Client` instance.
+4. The log level by default is set to WARN. You can change it to DEBUG if you want to debug the client by running `client.logger.level = Logger::DEBUG`, where client is your initialized `PostHog::Client` instance.
 5. Default polling interval for feature flags is now set at 30 seconds. If you don't want local evaluation, don't set a personal API key in the library.
 6. Feature flag defaults apply only when there's an error fetching feature flag results. Earlier, if the default was set to `True`, even if a flag resolved to `False`, the default would override this.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.0
+
+Breaking changes:
+
+1. `Client` initialisation doesn't take the `api_host` parameter anymore. Instead, it takes the `host` parameter, which needs to be fully qualified. For example: `https://api.posthog.com` is valid, while `api.posthog.com` is not valid.
+2. 
+
 # 1.3.0 - 2022-06-24
 
 - Add support for running the client in "No-op" mode for testing (https://github.com/PostHog/posthog-ruby/pull/15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
 3. `Client` initialisation doesn't take the `api_host` parameter anymore. Instead, it takes the `host` parameter, which needs to be fully qualified. For example: `https://api.posthog.com` is valid, while `api.posthog.com` is not valid.
 4. The log level by default is set to INFO. You can change it to DEBUG if you want to debug the client by running `client.logger.level = Logger::INFO`, where client is your initialized `PostHog::Client` instance.
 5. Default polling interval for feature flags is now set at 30 seconds. If you don't want local evaluation, don't set a personal API key in the library.
+6. Feature flag defaults apply only when there's an error fetching feature flag results. Earlier, if the default was set to `True`, even if a flag resolved to `False`, the default would override this.
 
 New Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Breaking changes:
 3. `Client` initialisation doesn't take the `api_host` parameter anymore. Instead, it takes the `host` parameter, which needs to be fully qualified. For example: `https://api.posthog.com` is valid, while `api.posthog.com` is not valid.
 4. The log level by default is set to WARN. You can change it to DEBUG if you want to debug the client by running `client.logger.level = Logger::DEBUG`, where client is your initialized `PostHog::Client` instance.
 5. Default polling interval for feature flags is now set at 30 seconds. If you don't want local evaluation, don't set a personal API key in the library.
-6. Feature flag defaults apply only when there's an error fetching feature flag results. Earlier, if the default was set to `True`, even if a flag resolved to `False`, the default would override this.
+6. Feature flag defaults are no more. Now, if a flag fails to compute for whatever reason, it will return `nil`. Otherwise, it returns either true or false. In case of `get_feature_flag`, it may also return a string variant value.
 
 New Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,18 @@
 
 Breaking changes:
 
-1. `Client` initialisation doesn't take the `api_host` parameter anymore. Instead, it takes the `host` parameter, which needs to be fully qualified. For example: `https://api.posthog.com` is valid, while `api.posthog.com` is not valid.
-2. 
+1. Minimum PostHog version requirement: 1.38
+2. Regular feature flag evaluation (i.e. by requesting from your PostHog servers) doesn't require a personal API key.
+3. `Client` initialisation doesn't take the `api_host` parameter anymore. Instead, it takes the `host` parameter, which needs to be fully qualified. For example: `https://api.posthog.com` is valid, while `api.posthog.com` is not valid.
+4. The log level by default is set to INFO. You can change it to DEBUG if you want to debug the client by running `client.logger.level = Logger::INFO`, where client is your initialized `PostHog::Client` instance.
+5. Default polling interval for feature flags is now set at 30 seconds. If you don't want local evaluation, don't set a personal API key in the library.
+
+New Changes:
+
+1. You can now evaluate feature flags locally (i.e. without sending a request to your PostHog servers) by setting a personal API key, and passing in groups and person properties to `is_feature_enabled` and `get_feature_flag` calls.
+    1. Note that `group_properties` and `person_properties` parameters don't accept symbols as hash keys, only strings.
+2. Introduces a `get_all_flags` method that returns all feature flags. This is useful for when you want to seed your frontend with some initial flags, given a user ID.
+
 
 # 1.3.0 - 2022-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Breaking changes:
 New Changes:
 
 1. You can now evaluate feature flags locally (i.e. without sending a request to your PostHog servers) by setting a personal API key, and passing in groups and person properties to `is_feature_enabled` and `get_feature_flag` calls.
-    1. Note that `group_properties` and `person_properties` parameters don't accept symbols as hash keys, only strings.
 2. Introduces a `get_all_flags` method that returns all feature flags. This is useful for when you want to seed your frontend with some initial flags, given a user ID.
 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@ Please see the main [PostHog docs](https://posthog.com/docs).
 
 Specifically, the [Ruby integration](https://posthog.com/docs/integrations/ruby-integration) details.
 
+## Developing Locally
+
+1. Install Ruby (and optionally `rbenv` to control ruby versions)
+2. Install Bundler
+3. Run `bundle install` to install dependencies
+
+## Running example file
+
+1. Build the `posthog-ruby` gem by calling: `gem build posthog-ruby.gemspec`.
+2. Install the gem locally: `gem install ./posthog-ruby-<version>.gem`
+3. Run `ruby example.rb`
+
+TODO: Doesn't work locally, defaults to https, ssl_verification only on workers, not on the whole client
+-> One part uses api_host, the other uses host, which is too messy.
+
+## Testing
+
+1. Run `bundle exec rspec`
+2. An example of running specific tests: `bundle exec rspec spec/posthog/client_spec.rb:26`
+
 ## Questions?
 
 ### [Join our Slack community.](https://join.slack.com/t/posthogusers/shared_invite/enQtOTY0MzU5NjAwMDY3LTc2MWQ0OTZlNjhkODk3ZDI3NDVjMDE1YjgxY2I4ZjI4MzJhZmVmNjJkN2NmMGJmMzc2N2U3Yjc3ZjI5NGFlZDQ)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Specifically, the [Ruby integration](https://posthog.com/docs/integrations/ruby-
 2. Install the gem locally: `gem install ./posthog-ruby-<version>.gem`
 3. Run `ruby example.rb`
 
-TODO: Doesn't work locally, defaults to https, ssl_verification only on workers, not on the whole client
--> One part uses api_host, the other uses host, which is too messy.
-
 ## Testing
 
 1. Run `bundle exec rspec`

--- a/example.rb
+++ b/example.rb
@@ -4,8 +4,8 @@
 require 'posthog-ruby'
 
 posthog = PostHog::Client.new({
-   api_key: "", # You can find this key on the /setup page in PostHog
-   personal_api_key: "", # Required for local feature flag evaluation
+   api_key: "phc_EKriuIZ8en7eBMCKkkgraMERQXkVM6g2gD050z2HIqf", # You can find this key on the /setup page in PostHog
+   personal_api_key: "phx_XouNv5HTWQZkUvGkC4C8yq8cVmTI5eQ3oEkAWvniERn", # Required for local feature flag evaluation
    host: "http://localhost:8000", # Where you host PostHog. You can remove this line if using app.posthog.com
    on_error: Proc.new { |status, msg| print msg },
    feature_flags_polling_interval: 10, # How often to poll for feature flags

--- a/example.rb
+++ b/example.rb
@@ -4,8 +4,8 @@
 require 'posthog-ruby'
 
 posthog = PostHog::Client.new({
-   api_key: "phc_EKriuIZ8en7eBMCKkkgraMERQXkVM6g2gD050z2HIqf", # You can find this key on the /setup page in PostHog
-   personal_api_key: "phx_XouNv5HTWQZkUvGkC4C8yq8cVmTI5eQ3oEkAWvniERn", # Required for local feature flag evaluation
+   api_key: "", # You can find this key on the /setup page in PostHog
+   personal_api_key: "", # Required for local feature flag evaluation
    host: "http://localhost:8000", # Where you host PostHog. You can remove this line if using app.posthog.com
    on_error: Proc.new { |status, msg| print msg },
    feature_flags_polling_interval: 10, # How often to poll for feature flags
@@ -18,8 +18,6 @@ puts(posthog.is_feature_enabled("beta-feature", "distinct_id"))
 puts(posthog.is_feature_enabled("beta-feature", "new_distinct_id"))
 puts(posthog.is_feature_enabled("beta-feature", "distinct_id", {"company" => "id:5"}))
 
-# puts("sleeping")
-# sleep 5
 
 puts(posthog.is_feature_enabled("beta-feature", "distinct_id"))
 
@@ -41,7 +39,6 @@ posthog.group_identify({group_type: "company", group_key: "id:5", properties: {"
 # properties set only once to the person
 posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { "$set_once": {"self_serve_signup": true}}})
 
-# sleep 3
 # this will not change the property (because it was already set)
 posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { "$set_once": {"self_serve_signup": false}}})
 
@@ -56,5 +53,13 @@ posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { 
 
 # Assume test-flag has `City Name = Sydney` as a person property set, then this will evaluate locally & return true
 puts posthog.is_feature_enabled("test-flag", "random_id_12345", person_properties: {"$geoip_city_name" => "Sydney"})
+
+puts posthog.is_feature_enabled("test-flag", "distinct_id_random_22", person_properties={"$geoip_city_name": "Sydney"}, only_evaluate_locally: true)
+
+
+puts posthog.get_all_flags("distinct_id_random_22")
+puts posthog.get_all_flags("distinct_id_random_22", only_evaluate_locally: true)
+puts posthog.get_all_flags("distinct_id_random_22", person_properties: {"$geoip_city_name": "Sydney"}, only_evaluate_locally: true)
+
 
 posthog.shutdown()

--- a/example.rb
+++ b/example.rb
@@ -4,8 +4,8 @@
 require 'posthog-ruby'
 
 posthog = PostHog::Client.new({
-   api_key: "phc_EKriuIZ8en7eBMCKkkgraMERQXkVM6g2gD050z2HIqf", # You can find this key on the /setup page in PostHog
-   personal_api_key: "phx_XouNv5HTWQZkUvGkC4C8yq8cVmTI5eQ3oEkAWvniERn", # Required for local feature flag evaluation
+   api_key: "", # You can find this key on the /setup page in PostHog
+   personal_api_key: "", # Required for local feature flag evaluation
    host: "http://localhost:8000", # Where you host PostHog. You can remove this line if using app.posthog.com
    on_error: Proc.new { |status, msg| print msg },
    feature_flags_polling_interval: 10, # How often to poll for feature flags

--- a/example.rb
+++ b/example.rb
@@ -7,17 +7,18 @@ posthog = PostHog::Client.new({
    api_key: "phc_EKriuIZ8en7eBMCKkkgraMERQXkVM6g2gD050z2HIqf", # You can find this key on the /setup page in PostHog
    personal_api_key: "phx_XouNv5HTWQZkUvGkC4C8yq8cVmTI5eQ3oEkAWvniERn", # Required for local feature flag evaluation
    host: "http://localhost:8000", # Where you host PostHog. You can remove this line if using app.posthog.com
-   on_error: Proc.new { |status, msg| print msg }
+   on_error: Proc.new { |status, msg| print msg },
+   feature_flags_polling_interval: 10, # How often to poll for feature flags
 })
-
+posthog.logger.level = Logger::DEBUG
 # Capture an event
 posthog.capture({distinct_id: "distinct_id", event: "event", properties: {"property1": "value", "property2": "value"}, send_feature_flags: true})
 
 puts(posthog.is_feature_enabled("beta-feature", "distinct_id"))
 puts(posthog.is_feature_enabled("beta-feature", "new_distinct_id"))
-puts(posthog.is_feature_enabled("beta-feature", "distinct_id", {"company": "id:5"}))
+puts(posthog.is_feature_enabled("beta-feature", "distinct_id", {"company" => "id:5"}))
 
-puts("sleeping")
+# puts("sleeping")
 # sleep 5
 
 puts(posthog.is_feature_enabled("beta-feature", "distinct_id"))
@@ -46,5 +47,14 @@ posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { 
 
 posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { "$set": {"current_browser": "Chrome"}}})
 posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { "$set": {"current_browser": "Firefox"}}})
+
+
+#############################################################################################
+# Local Evaluation Examples
+# requires a personal API key to work
+#############################################################################################
+
+# Assume test-flag has `City Name = Sydney` as a person property set, then this will evaluate locally & return true
+puts posthog.is_feature_enabled("test-flag", "random_id_12345", person_properties: {"$geoip_city_name" => "Sydney"})
 
 posthog.shutdown()

--- a/example.rb
+++ b/example.rb
@@ -4,9 +4,9 @@
 require 'posthog-ruby'
 
 posthog = PostHog::Client.new({
-   api_key: "", # You can find this key on the /setup page in PostHog
-   personal_api_key: "", # optional?
-   api_host: "https://localhost:8000", # Where you host PostHog. You can remove this line if using app.posthog.com
+   api_key: "phc_EKriuIZ8en7eBMCKkkgraMERQXkVM6g2gD050z2HIqf", # You can find this key on the /setup page in PostHog
+   personal_api_key: "phx_XouNv5HTWQZkUvGkC4C8yq8cVmTI5eQ3oEkAWvniERn", # Required for local feature flag evaluation
+   host: "http://localhost:8000", # Where you host PostHog. You can remove this line if using app.posthog.com
    on_error: Proc.new { |status, msg| print msg }
 })
 
@@ -14,10 +14,11 @@ posthog = PostHog::Client.new({
 posthog.capture({distinct_id: "distinct_id", event: "event", properties: {"property1": "value", "property2": "value"}, send_feature_flags: true})
 
 puts(posthog.is_feature_enabled("beta-feature", "distinct_id"))
+puts(posthog.is_feature_enabled("beta-feature", "new_distinct_id"))
 puts(posthog.is_feature_enabled("beta-feature", "distinct_id", {"company": "id:5"}))
 
 puts("sleeping")
-sleep 5
+# sleep 5
 
 puts(posthog.is_feature_enabled("beta-feature", "distinct_id"))
 
@@ -39,11 +40,11 @@ posthog.group_identify({group_type: "company", group_key: "id:5", properties: {"
 # properties set only once to the person
 posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { "$set_once": {"self_serve_signup": true}}})
 
-sleep 3
+# sleep 3
 # this will not change the property (because it was already set)
 posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { "$set_once": {"self_serve_signup": false}}})
 
 posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { "$set": {"current_browser": "Chrome"}}})
 posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { "$set": {"current_browser": "Firefox"}}})
 
-# posthog.shutdown()
+posthog.shutdown()

--- a/example.rb
+++ b/example.rb
@@ -50,7 +50,7 @@ posthog.capture({distinct_id: "new_distinct_id", event: "signup", properties: { 
 
 
 #############################################################################################
-# Local Evaluation Examples
+# Feature flag local evaluation examples
 # requires a personal API key to work
 #############################################################################################
 

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -143,8 +143,12 @@ class PostHog
       @queue.length
     end
 
-    def is_feature_enabled(flag_key, distinct_id, default_value = false, groups: {}, person_properties: {}, group_properties: {}, only_evaluate_locally: false, send_feature_flag_events: true)
-      return !!get_feature_flag(flag_key, distinct_id, default_value, groups: groups, person_properties: person_properties, group_properties: group_properties, only_evaluate_locally: only_evaluate_locally, send_feature_flag_events: send_feature_flag_events)
+    def is_feature_enabled(flag_key, distinct_id, groups: {}, person_properties: {}, group_properties: {}, only_evaluate_locally: false, send_feature_flag_events: true)
+      response = get_feature_flag(flag_key, distinct_id, groups: groups, person_properties: person_properties, group_properties: group_properties, only_evaluate_locally: only_evaluate_locally, send_feature_flag_events: send_feature_flag_events)
+      if response.nil?
+        return nil
+      end
+      !!response
     end
 
     # Returns whether the given feature flag is enabled for the given user or not
@@ -167,8 +171,8 @@ class PostHog
     # ```ruby
     #     group_properties: {"organization": {"name": "PostHog", "employees": 11}}
     # ```
-    def get_feature_flag(key, distinct_id, default_value=false, groups: {}, person_properties: {}, group_properties: {}, only_evaluate_locally: false, send_feature_flag_events: true)
-      feature_flag_response, flag_was_locally_evaluated = @feature_flags_poller.get_feature_flag(key, distinct_id, default_value, groups, person_properties, group_properties, only_evaluate_locally)
+    def get_feature_flag(key, distinct_id, groups: {}, person_properties: {}, group_properties: {}, only_evaluate_locally: false, send_feature_flag_events: true)
+      feature_flag_response, flag_was_locally_evaluated = @feature_flags_poller.get_feature_flag(key, distinct_id, groups, person_properties, group_properties, only_evaluate_locally)
 
       feature_flag_reported_key = "#{key}_#{feature_flag_response}"
       if !@distinct_id_has_sent_flag_calls[distinct_id].include?(feature_flag_reported_key) && send_feature_flag_events

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -163,8 +163,8 @@ class PostHog
     # `group_properties` take the format: { group_type_name: { group_properties } }
     # So, for example, if you have the group type "organization" and the group key "5", with the properties name, and employee count,
     # you'll send these as:
-    # ```python
-    #     group_properties={"organization": {"name": "PostHog", "employees": 11}}
+    # ```ruby
+    #     group_properties: {"organization": {"name": "PostHog", "employees": 11}}
     # ```
     def get_feature_flag(key, distinct_id, default_value=false, groups: {}, person_properties: {}, group_properties: {})
       feature_flag = @feature_flags_poller.get_feature_flag(key, distinct_id, default_value, groups, person_properties, group_properties)

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -179,7 +179,7 @@ class PostHog
       return feature_flag
     end
 
-    def get_all_flags(distinct_id, groups={}, person_properties={}, group_properties={})
+    def get_all_flags(distinct_id, groups: {}, person_properties: {}, group_properties: {})
       return @feature_flags_poller.get_all_flags(distinct_id, groups, person_properties, group_properties)
     end
 

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -21,6 +21,7 @@ class PostHog
     #   queued for testing. Defaults to +false+.
     # @option opts [Proc] :on_error Handles error calls from the API.
     # @option opts [String] :host Fully qualified hostname of the PostHog server. Defaults to `https://app.posthog.com`
+    # @option opts [Integer] :feature_flags_polling_interval How often to poll for feature flag definition changes. Measured in seconds, defaults to 30.
     def initialize(opts = {})
       symbolize_keys!(opts)
 
@@ -184,6 +185,14 @@ class PostHog
       return feature_flag
     end
 
+    # Returns all flags for a given user
+    #
+    # @param [String] distinct_id The distinct id of the user
+    # @param [Hash] groups
+    # @param [Hash] person_properties key-value pairs of properties to associate with the user.
+    # @param [Hash] group_properties
+    # 
+    # @return [Hash] String (not symbol) key value pairs of flag and their values
     def get_all_flags(distinct_id, groups: {}, person_properties: {}, group_properties: {})
       return @feature_flags_poller.get_all_flags(distinct_id, groups, person_properties, group_properties)
     end

--- a/lib/posthog/defaults.rb
+++ b/lib/posthog/defaults.rb
@@ -1,5 +1,8 @@
 class PostHog
   module Defaults
+
+    MAX_HASH_SIZE = 50_000
+
     module Request
       HOST = 'app.posthog.com'
       PORT = 443

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -66,7 +66,7 @@ class PostHog
       end
     end
 
-    def get_feature_flag(key, distinct_id, default_result = false, groups = {}, person_properties = {}, group_properties = {}, only_evaluate_locally = false)
+    def get_feature_flag(key, distinct_id, groups = {}, person_properties = {}, group_properties = {}, only_evaluate_locally = false)
       # make sure they're loaded on first run
       load_feature_flags
 
@@ -105,10 +105,12 @@ class PostHog
         begin
           flags = get_feature_variants(distinct_id, groups, person_properties, group_properties)
           response = flags[key]
+          if response.nil?
+            response = false
+          end
           logger.debug "Successfully computed flag remotely: #{key} -> #{response}"
         rescue StandardError => e
           logger.error "Error computing flag remotely: #{e}. #{e.backtrace.join("\n")}"
-          response = default_result
         end
       end
 
@@ -338,7 +340,6 @@ class PostHog
       uri = URI("#{@host}/api/feature_flag/local_evaluation?token=#{@project_api_key}")
       req = Net::HTTP::Get.new(uri)
       req['Authorization'] = "Bearer #{@personal_api_key}"
-      req['User-Agent'] = "posthog-ruby#{PostHog::VERSION}"
 
       _request(uri, req)
     end

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -32,13 +32,13 @@ class PostHog
         ) { _load_feature_flags }
 
       # If no personal API key, disable local evaluation & thus polling for definitions
-      if !@personal_api_key.nil?
+      if @personal_api_key.nil?
+        logger.info "No personal API key provided, disabling local evaluation"
+        @loaded_flags_successfully_once.make_true
+      else
         # load once before timer
         load_feature_flags
         @task.execute
-      else
-        logger.info "No personal API key provided, disabling local evaluation"
-        @loaded_flags_successfully_once.make_true
       end
     end
 

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -66,7 +66,7 @@ class PostHog
       end
     end
 
-    def get_feature_flag(key, distinct_id, default_result = false, groups = {}, person_properties = {}, group_properties = {})
+    def get_feature_flag(key, distinct_id, default_result = false, groups = {}, person_properties = {}, group_properties = {}, only_evaluate_locally = false)
       # make sure they're loaded on first run
       load_feature_flags
 
@@ -99,7 +99,9 @@ class PostHog
         end
       end
 
-      if response.nil?
+      flag_was_locally_evaluated = !response.nil?
+
+      if !flag_was_locally_evaluated && !only_evaluate_locally
         begin
           flags = get_feature_variants(distinct_id, groups, person_properties, group_properties)
           response = flags[key]
@@ -110,10 +112,10 @@ class PostHog
         end
       end
 
-      return response
+      [response, flag_was_locally_evaluated]
     end
 
-    def get_all_flags(distinct_id, groups = {}, person_properties = {}, group_properties = {})
+    def get_all_flags(distinct_id, groups = {}, person_properties = {}, group_properties = {}, only_evaluate_locally = false)
       # returns a string hash of all flags
 
       # make sure they're loaded on first run
@@ -133,7 +135,7 @@ class PostHog
         end
       end
 
-      if fallback_to_decide
+      if fallback_to_decide && !only_evaluate_locally
         begin
           flags = get_feature_variants(distinct_id, groups, person_properties, group_properties)
           response = {**response, **flags}

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -38,14 +38,6 @@ class PostHog
       end
     end
 
-    def is_simple_flag_enabled(key, distinct_id, rollout_percentage)
-      hash = Digest::SHA1.hexdigest "#{key}.#{distinct_id}"
-      return(
-        (Integer(hash[0..14], 16).to_f / 0xfffffffffffffff) <=
-          (rollout_percentage / 100)
-      )
-    end
-
     def load_feature_flags(force_reload = false)
       if @loaded_flags_successfully_once.false? || force_reload
         _load_feature_flags
@@ -96,7 +88,7 @@ class PostHog
         end
       end
 
-      if response == nil
+      if response.nil?
         begin
           flags = get_feature_variants(distinct_id, groups, person_properties, group_properties)
           response = flags[key]

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -4,7 +4,12 @@ require 'json'
 require 'posthog/version'
 require 'posthog/logging'
 require 'digest'
+
 class PostHog
+
+  class InconclusiveMatchError < StandardError
+  end
+
   class FeatureFlagsPoller
     include PostHog::Logging
 
@@ -12,52 +17,25 @@ class PostHog
       @polling_interval = polling_interval || 60 * 5
       @personal_api_key = personal_api_key
       @project_api_key = project_api_key
-      @host = host || 'app.posthog.com'
+      @host = host
       @feature_flags = Concurrent::Array.new
+      @group_type_mapping = Concurrent::Hash.new
       @loaded_flags_successfully_once = Concurrent::AtomicBoolean.new
 
       @task =
         Concurrent::TimerTask.new(
           execution_interval: polling_interval,
-          timeout_interval: 15
         ) { _load_feature_flags }
 
-      # load once before timer
-      load_feature_flags
-      @task.execute
-    end
-
-    def is_feature_enabled(key, distinct_id, default_result = false, groups = {})
-      # make sure they're loaded on first run
-      load_feature_flags
-
-      return default_result unless @loaded_flags_successfully_once
-
-      feature_flag = nil
-
-      @feature_flags.each do |flag|
-        if key == flag['key']
-          feature_flag = flag
-          break
-        end
-      end
-
-      return default_result if !feature_flag
-
-      flag_rollout_pctg =
-        if feature_flag['rollout_percentage']
-          feature_flag['rollout_percentage']
-        else
-          100
-        end
-      if feature_flag['is_simple_flag']
-        return is_simple_flag_enabled(key, distinct_id, flag_rollout_pctg)
+      # If no personal API key, disable local evaluation & thus polling for definitions
+      if !@personal_api_key.nil?
+        # load once before timer
+        load_feature_flags
+        @task.execute
       else
-        res = get_feature_variants(distinct_id, groups)
-        return res[key] ? true : default_result
+        logger.info "No personal API key provided, disabling local evaluation"
+        @loaded_flags_successfully_once.make_true
       end
-
-      return false
     end
 
     def is_simple_flag_enabled(key, distinct_id, rollout_percentage)
@@ -74,64 +52,289 @@ class PostHog
       end
     end
 
-    def get_feature_variants(distinct_id, groups = nil)
+    def get_feature_variants(distinct_id, groups={}, person_properties={}, group_properties={})
+      # TODO: why isn't the default simply {} ?
       groups = {} unless groups.is_a?(Hash)
 
       request_data = {
-            "distinct_id": distinct_id,
-            "personal_api_key": @personal_api_key,
-            "groups": groups
+        "distinct_id": distinct_id,
+        "groups": groups,
+        "person_properties": person_properties,
+        "group_properties": group_properties,
       }
 
-      decide_data = _request('POST', 'decide/?v=2', false)
-      feature_variants = decide_data["featureFlags"]
-      return feature_variants
+      decide_data = _request_feature_flag_evaluation(request_data)
+
+      if !decide_data.key?('featureFlags')
+        raise StandardError.new(decide_data.to_json)
+      else
+        feature_variants = decide_data["featureFlags"] || {}
+        return feature_variants
+      end
     end
 
-    def get_feature_flag(key, distinct_id, groups = {})
-      variants = get_feature_variants(distinct_id, groups=groups)
-      return variants.fetch(key)
+    def get_feature_flag(key, distinct_id, default_result = false, groups = {}, person_properties = {}, group_properties = {})
+      # make sure they're loaded on first run
+      load_feature_flags
+
+      response = nil
+      feature_flag = nil
+
+      @feature_flags.each do |flag|
+        if key == flag['key']
+          feature_flag = flag
+          break
+        end
+      end
+
+      if !feature_flag.nil?
+        begin
+          response = _compute_flag_locally(feature_flag, distinct_id, groups, person_properties, group_properties)
+        rescue InconclusiveMatchError => e
+        rescue StandardError => e
+          logger.error "Error computing flag locally: #{e}. #{e.backtrace.join("\n")}"
+        end
+      end
+
+      if response == nil
+        begin
+          flags = get_feature_variants(distinct_id, groups, person_properties, group_properties)
+          response = flags[key]
+        rescue StandardError => e
+          logger.error "Error computing flag remotely: #{e}"
+          response = default_result
+        end
+      end
+
+      return response
     end
 
     def shutdown_poller()
       @task.shutdown
     end
 
-    private
+    # Class methods
 
-    def _load_feature_flags()
-      res = _request('GET', 'api/feature_flag', true)
-      @feature_flags.clear
-      @feature_flags = res['results'].filter { |flag| flag['active'] }
-      if @loaded_flags_successfully_once.false?
-        @loaded_flags_successfully_once.make_true
+    def self.match_property(property, property_values)
+      # only looks for matches where key exists in property_values
+      # doesn't support operator is_not_set
+
+      key = property['key']
+      value = property['value']
+      operator = property['operator'] || 'exact'
+
+      if !property_values.has_key?(key)
+        raise InconclusiveMatchError.new("Property #{key} not found in property_values")
+      elsif operator == 'is_not_set'
+        raise InconclusiveMatchError.new("Operator is_not_set not supported")
+      end
+
+      override_value = property_values[key]
+
+      if operator == 'exact'
+        if value.is_a?(Array)
+          return value.include?(override_value)
+        end
+        return value == override_value
+      elsif operator == 'is_not'
+        if value.is_a?(Array)
+          return !value.include?(override_value)
+        end
+        return value != override_value
+      elsif operator == 'is_set'
+        return property_values.has_key?(key)
+      elsif operator == 'icontains'
+        return override_value.to_s.downcase.include?(value.to_s.downcase)
+      elsif operator == 'not_icontains'
+        return !override_value.to_s.downcase.include?(value.to_s.downcase)
+      elsif operator == 'regex'
+        is_valid_regex(value.to_s) and !Regexp.new(value.to_s).match(override_value.to_s).nil?
+      elsif operator == 'not_regex'
+        is_valid_regex(value.to_s) and Regexp.new(value.to_s).match(override_value.to_s).nil?
+      elsif operator == 'gt'
+        override_value.class == value.class and override_value > value
+      elsif operator == 'gte'
+        override_value.class == value.class and override_value >= value
+      elsif operator == 'lt'
+        override_value.class == value.class and override_value < value
+      elsif operator == 'lte'
+        override_value.class == value.class and override_value <= value
+      else
+        return false
+      end
+
+    end
+
+    def self.is_valid_regex(regex)
+      begin
+        Regexp.new(regex)
+        return true
+      rescue RegexpError
+        return false
       end
     end
 
-    def _request(method, endpoint, use_personal_api_key = false, data = {})
-      uri = URI("https://#{@host}/#{endpoint}")
-      req = nil
-      if use_personal_api_key
-        uri = URI("https://#{@host}/#{endpoint}/?token=#{@project_api_key}")
-        req = Net::HTTP::Get.new(uri)
-        req['Authorization'] = "Bearer #{@personal_api_key}"
-      else
-        req = Net::HTTP::Post.new(uri)
-        req['Content-Type'] = 'application/json'
-        data['token'] = @project_api_key
-        req.body = data.to_json
+    private
+
+    def _compute_flag_locally(flag, distinct_id, groups = {}, person_properties = {}, group_properties = {})
+      if flag['ensure_experience_continuity']
+        raise InconclusiveMatchError.new("Flag has experience continuity enabled")
       end
 
+      flag_filters = flag['filters'] || {}
+      aggregation_group_type_index = flag_filters['aggregation_group_type_index']
+      if !aggregation_group_type_index.nil?
+        group_name = @group_type_mapping[aggregation_group_type_index.to_s]
+
+        if group_name.nil?
+          logger.warn "[FEATURE FLAGS] Unknown group type index #{aggregation_group_type_index} for feature flag #{flag['key']}"
+          # failover to `/decide/`
+          raise InconclusiveMatchError.new("Flag has unknown group type index")
+        end
+
+        if !groups.has_key?(group_name)
+          # Group flags are never enabled if appropriate `groups` aren't passed in
+          # don't failover to `/decide/`, since response will be the same
+          logger.warn "[FEATURE FLAGS] Can't compute group feature flag: #{flag['key']} without group names passed in"
+          return false
+        end
+
+        focused_group_properties = group_properties[group_name]
+        return match_feature_flag_properties(flag, groups[group_name], focused_group_properties)
+      else
+        return match_feature_flag_properties(flag, distinct_id, person_properties)
+      end
+
+    end
+
+    def match_feature_flag_properties(flag, distinct_id, properties)
+      flag_filters = flag['filters'] || {}
+      flag_conditions = flag_filters['groups'] || []
+      is_inconclusive = false
+      result = nil
+
+      flag_conditions.each do |condition|
+        begin
+          if is_condition_match(flag, distinct_id, condition, properties)
+            result = get_matching_variant(flag, distinct_id) || true
+            break
+          end
+        rescue InconclusiveMatchError => e
+          is_inconclusive = true
+        end
+      end
+
+      if !result.nil?
+        return result
+      elsif is_inconclusive
+        raise InconclusiveMatchError.new("Can't determine if feature flag is enabled or not with given properties")
+      end
+
+      # We can only return False when either all conditions are False, or
+      # no condition was inconclusive.
+      return false
+    end
+
+    def is_condition_match(flag, distinct_id, condition, properties)
+      rollout_percentage = condition['rollout_percentage']
+
+      if !(condition['properties'] || []).empty?
+        if !condition['properties'].all? { |prop|
+            FeatureFlagsPoller.match_property(prop, properties)
+          }
+          return false
+        elsif rollout_percentage.nil?
+          return true
+        end
+      end
+
+      if !rollout_percentage.nil? and _hash(flag['key'], distinct_id) > (rollout_percentage.to_f/100)
+        return false
+      end
+      
+      return true
+    end
+
+    # This function takes a distinct_id and a feature flag key and returns a float between 0 and 1.
+    # Given the same distinct_id and key, it'll always return the same float. These floats are
+    # uniformly distributed between 0 and 1, so if we want to show this feature to 20% of traffic
+    # we can do _hash(key, distinct_id) < 0.2
+    def _hash(key, distinct_id, salt="")
+      hash_key = Digest::SHA1.hexdigest "#{key}.#{distinct_id}#{salt}"
+      return (Integer(hash_key[0..14], 16).to_f / 0xfffffffffffffff)
+    end
+
+    def get_matching_variant(flag, distinct_id)
+      hash_value = _hash(flag['key'], distinct_id, salt="variant")
+      variant_lookup_table(flag).each do |variant|
+        if (
+           hash_value >= variant[:value_min] and hash_value <= variant[:value_max]
+        )
+          return variant[:key]
+        end
+      end
+      return nil
+    end
+
+    def variant_lookup_table(flag)
+      lookup_table = []
+      value_min = 0
+      multivariates = ((flag['filters'] || {})['multivariate'] || {})['variants'] || []
+      multivariates.each do |variant|
+        value_max = value_min + variant['rollout_percentage'].to_f / 100
+        lookup_table << {'value_min': value_min, 'value_max': value_max, 'key': variant['key']}
+        value_min = value_max
+      end
+      return lookup_table
+    end
+
+    def _load_feature_flags()
+      res = _request_feature_flag_definitions
+      @feature_flags.clear
+
+      if !res.key?('flags')
+        logger.error "Failed to load feature flags: #{res}"
+      else
+        @feature_flags = res['flags'].filter { |flag| flag['active'] }
+        @group_type_mapping = res['group_type_mapping'] || {}
+        if @loaded_flags_successfully_once.false?
+          @loaded_flags_successfully_once.make_true
+        end
+      end
+    end
+
+    def _request_feature_flag_definitions
+      uri = URI("#{@host}/api/feature_flag/local_evaluation?token=#{@project_api_key}")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{@personal_api_key}"
       req['User-Agent'] = "posthog-ruby#{PostHog::VERSION}"
+
+      return _request(uri, req)
+    end
+
+    def _request_feature_flag_evaluation(data={})
+      uri = URI("#{@host}/decide/?v=2")
+      req = Net::HTTP::Post.new(uri)
+      req['Content-Type'] = 'application/json'
+      data['token'] = @project_api_key
+      req.body = data.to_json
+
+      return _request(uri, req)
+    end
+
+    def _request(uri, request_object)
+
+      request_object['User-Agent'] = "posthog-ruby#{PostHog::VERSION}"
 
       begin
         res_body = nil
-        res =
-          Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
-            res = http.request(req)
-            res_body = JSON.parse(res.body)
-            return res_body
-          end
+        Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+          res = http.request(request_object)
+          p res
+          res_body = JSON.parse(res.body)
+          p res_body
+          return res_body
+        end
       rescue Timeout::Error,
              Errno::EINVAL,
              Errno::ECONNRESET,
@@ -142,6 +345,6 @@ class PostHog
         logger.debug("Unable to complete request to #{uri}")
         throw e
       end
-    end
+    end  
   end
 end

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -45,8 +45,6 @@ class PostHog
     end
 
     def get_feature_variants(distinct_id, groups={}, person_properties={}, group_properties={})
-      # TODO: why isn't the default simply {} ?
-      groups = {} unless groups.is_a?(Hash)
 
       request_data = {
         "distinct_id": distinct_id,

--- a/lib/posthog/logging.rb
+++ b/lib/posthog/logging.rb
@@ -44,7 +44,7 @@ class PostHog
           else
             logger = Logger.new STDOUT
             logger.progname = 'PostHog'
-            logger.level = Logger::INFO
+            logger.level = Logger::WARN
             logger
           end
         @logger = PrefixedLogger.new(base_logger, '[posthog-ruby]')

--- a/lib/posthog/logging.rb
+++ b/lib/posthog/logging.rb
@@ -23,6 +23,14 @@ class PostHog
     def error(msg)
       @logger.error("#{@prefix} #{msg}")
     end
+
+    def level=(severity)
+      @logger.level = severity
+    end
+
+    def level
+      @logger.level
+    end
   end
 
   module Logging
@@ -36,6 +44,7 @@ class PostHog
           else
             logger = Logger.new STDOUT
             logger.progname = 'PostHog'
+            logger.level = Logger::INFO
             logger
           end
         @logger = PrefixedLogger.new(base_logger, '[posthog-ruby]')

--- a/lib/posthog/send_worker.rb
+++ b/lib/posthog/send_worker.rb
@@ -28,7 +28,7 @@ class PostHog
       batch_size = options[:batch_size] || Defaults::MessageBatch::MAX_SIZE
       @batch = MessageBatch.new(batch_size)
       @lock = Mutex.new
-      @transport = Transport.new api_host: options[:api_host], skip_ssl_verification: options[:skip_ssl_verification]
+      @transport = Transport.new api_host: options[:host], skip_ssl_verification: options[:skip_ssl_verification]
     end
 
     # public: Continuously runs the loop to check for new events

--- a/lib/posthog/transport.rb
+++ b/lib/posthog/transport.rb
@@ -20,9 +20,11 @@ class PostHog
         options[:ssl] = uri.scheme == 'https'
         options[:port] = uri.port
       end
-      options[:host] ||= HOST
-      options[:port] ||= PORT
-      options[:ssl] ||= SSL
+
+      options[:host] = !options[:host].nil? ? options[:host] : HOST
+      options[:port] = !options[:port].nil? ? options[:port] : PORT
+      options[:ssl] = !options[:ssl].nil? ? options[:ssl] : SSL
+      
       @headers = options[:headers] || HEADERS
       @path = options[:path] || PATH
       @retries = options[:retries] || RETRIES

--- a/lib/posthog/utils.rb
+++ b/lib/posthog/utils.rb
@@ -86,6 +86,15 @@ class PostHog
     UTC_OFFSET_WITH_COLON = '%s%02d:%02d'
     UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.sub(':', '')
 
+    def is_valid_regex(regex)
+      begin
+        Regexp.new(regex)
+        return true
+      rescue RegexpError
+        return false
+      end
+    end
+
     class SizeLimitedHash < Hash
       def initialize(max_length, *args, &block)
         super(*args, &block)

--- a/lib/posthog/utils.rb
+++ b/lib/posthog/utils.rb
@@ -85,5 +85,19 @@ class PostHog
 
     UTC_OFFSET_WITH_COLON = '%s%02d:%02d'
     UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.sub(':', '')
+
+    class SizeLimitedHash < Hash
+      def initialize(max_length, *args, &block)
+        super(*args, &block)
+        @max_length = max_length
+      end
+
+      def []=(key, value)
+        if length >= @max_length
+          clear
+        end
+        super
+      end
+    end
   end
 end

--- a/posthog-ruby.gemspec
+++ b/posthog-ruby.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |spec|
   
   spec.add_dependency "concurrent-ruby", "~> 1", "< 1.1.10"
 
-  # TODO: timertask timeout pinning? "concurrent-ruby", "~> 1", "< 1.1.10"
-
   # Used in the executable testing script
   spec.add_development_dependency 'commander', '~> 4.4'
 

--- a/posthog-ruby.gemspec
+++ b/posthog-ruby.gemspec
@@ -15,7 +15,9 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 2.0'
   
-  spec.add_dependency 'concurrent-ruby'
+  spec.add_dependency "concurrent-ruby"
+
+  # TODO: timertask timeout pinning? "concurrent-ruby", "~> 1", "< 1.1.10"
 
   # Used in the executable testing script
   spec.add_development_dependency 'commander', '~> 4.4'

--- a/posthog-ruby.gemspec
+++ b/posthog-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 2.0'
   
-  spec.add_dependency "concurrent-ruby"
+  spec.add_dependency "concurrent-ruby", "~> 1", "< 1.1.10"
 
   # TODO: timertask timeout pinning? "concurrent-ruby", "~> 1", "< 1.1.10"
 

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 class PostHog
 
   RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = nil
-  # TODO: test that when `send_feature_flags` is true, and no personal API key is present, we don't blow up
 
   describe Client do
     let(:client) { Client.new(api_key: API_KEY, test_mode: true) }

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -106,7 +106,7 @@ class PostHog
         decide_res = {"featureFlags": {"beta-feature": "random-variant"}}
         # Mock response for decide
         api_feature_flag_res = {
-          "results": [
+          "flags": [
             {
               "id": 1,
               "name": '',
@@ -188,6 +188,7 @@ class PostHog
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
         stub_const("PostHog::Defaults::MAX_HASH_SIZE", 10)
+        stub_const("PostHog::VERSION", "1.2.4")
 
         c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
 
@@ -204,7 +205,7 @@ class PostHog
             "$feature_flag" => "beta-feature",
             "$feature_flag_response" => true,
             "$lib"=>"posthog-ruby",
-            "$lib_version"=>"1.3.0",
+            "$lib_version"=>"1.2.4",
           })
           expect(c.instance_variable_get(:@distinct_id_has_sent_flag_calls).length <= 10).to eq(true)
         end

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 class PostHog
+
+  RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = nil
+  # TODO: test that when `send_feature_flags` is true, and no personal API key is present, we don't blow up
+
   describe Client do
     let(:client) { Client.new(api_key: API_KEY, test_mode: true) }
 
@@ -18,7 +22,7 @@ class PostHog
       end
 
       it 'handles skip_ssl_verification' do
-        expect(PostHog::Transport).to receive(:new).with({api_host: nil, skip_ssl_verification: true})
+        expect(PostHog::Transport).to receive(:new).with({api_host: 'https://app.posthog.com', skip_ssl_verification: true})
         expect { Client.new api_key: API_KEY, skip_ssl_verification: true }.to_not raise_error
       end
     end
@@ -115,7 +119,7 @@ class PostHog
 
         stub_request(
           :get,
-          'https://app.posthog.com/api/feature_flag/?token=testsecret'
+          'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
         stub_request(:post, 'https://app.posthog.com/decide/?v=2')
           .to_return(status: 200, body: decide_res.to_json)

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -193,7 +193,7 @@ class PostHog
 
         expect(c.instance_variable_get(:@distinct_id_has_sent_flag_calls).length).to eq(0)
 
-        for i in 1..1000 do
+        1000.times { |i|
           distinct_id = "some-distinct-id#{i}"
           c.get_feature_flag("beta-feature", distinct_id)
 
@@ -207,7 +207,7 @@ class PostHog
             "$lib_version"=>"1.2.4",
           })
           expect(c.instance_variable_get(:@distinct_id_has_sent_flag_calls).length <= 10).to eq(true)
-        end
+        }
       end
 
       it 'captures groups' do

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -276,7 +276,7 @@ class PostHog
         expect(c.get_feature_flag('beta-feature', 'some-distinct-id2', person_properties: {"region": "USA", "name": "Aloha"})).to eq(true)
 
         # called for different user, but send configuration is false, so should NOT call capture again
-        expect(c.get_feature_flag('beta-feature', 'some-distinct-id2', person_properties: {"region": "USA", "name": "Aloha"}, send_feature_flag_events: false)).to eq(true)
+        expect(c.get_feature_flag('beta-feature', 'some-distinct-id23', person_properties: {"region": "USA", "name": "Aloha"}, send_feature_flag_events: false)).to eq(true)
 
         # called for different flag, falls back to decide, should call capture again
         expect(c).to receive(:capture).with({

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -607,6 +607,11 @@ class PostHog
 
   describe 'consistency tests' do
 
+    # These tests are the same across all libraries
+    # See https://github.com/PostHog/posthog/blob/master/posthog/test/test_feature_flag.py#L627
+    # where this test has directly been copied from.
+    # They ensure that the server and library hash calculations are in sync.
+
     it 'is consistent for simple flags' do
       api_feature_flag_res = {
         "flags": [

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -45,6 +45,8 @@ class PostHog
       c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
 
       expect(c.get_feature_flag("person-flag", "some-distinct-id", person_properties: {"region" => "USA"})).to eq(true)
+      expect(c.get_feature_flag("person-flag", "some-distinct-id", person_properties: {"region": "USA"})).to eq(true)
+      expect(c.get_feature_flag("person-flag", "some-distinct-id", person_properties: {"region": "Canada"})).to eq(false)
       expect(c.get_feature_flag("person-flag", "some-distinct-id", person_properties: {"region" => "Canada"})).to eq(false)
 
     end
@@ -91,10 +93,13 @@ class PostHog
 
       # groups not passed in, hence false
       expect(c.get_feature_flag("group-flag", "some-distinct-id", group_properties: {"company" => {"name" => "Project Name 1"}})).to eq(false)
+      expect(c.get_feature_flag("group-flag", "some-distinct-id", group_properties: {"company": {"name": "Project Name 1"}})).to eq(false)
       expect(c.get_feature_flag("group-flag", "some-distinct-2", group_properties: {"company" => {"name" => "Project Name 2"}})).to eq(false)
 
       # this is good
       expect(c.get_feature_flag("group-flag", "some-distinct-2", groups: {"company" => "amazon_without_rollout"}, group_properties: {"company" => {"name" => "Project Name 1"}})).to eq(true)
+      expect(c.get_feature_flag("group-flag", "some-distinct-2", groups: {"company": "amazon_without_rollout"}, group_properties: {"company" => {"name" => "Project Name 1"}})).to eq(true)
+      expect(c.get_feature_flag("group-flag", "some-distinct-2", groups: {"company" => "amazon_without_rollout"}, group_properties: {"company" => {"name": "Project Name 1"}})).to eq(true)
       
       # rollout % not met
       expect(c.get_feature_flag("group-flag", "some-distinct-2", groups: {"company" => "amazon"}, group_properties: {"company" => {"name" => "Project Name 1"}})).to eq(false)
@@ -215,6 +220,7 @@ class PostHog
       c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
 
       expect(c.get_feature_flag("complex-flag", "some-distinct-id", person_properties: {"region" => "USA", "name" => "Aloha"})).to eq(true)
+      expect(c.get_feature_flag("complex-flag", "some-distinct-id", person_properties: {"region": "USA", "name": "Aloha"})).to eq(true)
       assert_not_requested :post, 'https://app.posthog.com/decide/?v=2'
       
       
@@ -1881,7 +1887,7 @@ class PostHog
         true,
       ]
 
-      for i in 0..999 do
+      1000.times { |i|
         distinctID = "distinct_id_#{i}"
 
         feature_flag_match = c.is_feature_enabled("simple-flag", distinctID)
@@ -1891,7 +1897,7 @@ class PostHog
         else
           expect(feature_flag_match).to be false
         end
-      end
+      }
     end
 
     it 'is consistent for multivariate flags' do
@@ -2932,7 +2938,7 @@ class PostHog
         "first-variant",
       ]
 
-      for i in 0..999 do
+      1000.times { |i|
         distinctID = "distinct_id_#{i}"
 
         feature_flag_match = c.get_feature_flag("multivariate-flag", distinctID)
@@ -2942,7 +2948,7 @@ class PostHog
         else
           expect(feature_flag_match).to be false
         end
-      end
+      }
     end
   end
 

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -384,7 +384,7 @@ class PostHog
       WebMock.reset_executed_requests!
     end
 
-    it 'experience continuity is not evaluated locally' do
+    it 'experience continuity flags are not evaluated locally' do
       api_feature_flag_res = {
         "flags": [
           {
@@ -420,7 +420,144 @@ class PostHog
       assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 1
     end
 
-    # TODO: 3 tests for get_all_flags
+    it 'get all flags with fallback' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+              "id": 1,
+              "name": "Beta Feature",
+              "key": "beta-feature",
+              "is_simple_flag": false,
+              "active": true,
+              "rollout_percentage": 100,
+              "filters": {
+                  "groups": [
+                      {
+                          "properties": [],
+                          "rollout_percentage": 100,
+                      }
+                  ]
+              },
+          },
+          {
+              "id": 2,
+              "name": "Beta Feature",
+              "key": "disabled-feature",
+              "is_simple_flag": false,
+              "active": true,
+              "filters": {
+                  "groups": [
+                      {
+                          "properties": [],
+                          "rollout_percentage": 0,
+                      }
+                  ]
+              },
+          },
+          {
+              "id": 3,
+              "name": "Beta Feature",
+              "key": "beta-feature2",
+              "is_simple_flag": false,
+              "active": true,
+              "filters": {
+                  "groups": [
+                      {
+                          "properties": [{"key": "country", "value": "US"}],
+                          "rollout_percentage": 0,
+                      }
+                  ]
+              },
+          },
+        ]
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+      .to_return(status: 200, body:{"featureFlags": {"beta-feature": "variant-1", "beta-feature2": "variant-2"}}.to_json)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      # beta-feature value overridden by /decide
+      expect(c.get_all_flags("distinct-id")).to eq({"beta-feature" => "variant-1", "beta-feature2" => "variant-2", "disabled-feature" => false})
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 1
+      WebMock.reset_executed_requests!
+
+    end
+
+    it 'get all flags with fallback, with no local flags' do
+      api_feature_flag_res = {
+        "flags": []
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+      .to_return(status: 200, body:{"featureFlags": {"beta-feature": "variant-1", "beta-feature2": "variant-2"}}.to_json)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      expect(c.get_all_flags("distinct-id")).to eq({"beta-feature" => "variant-1", "beta-feature2" => "variant-2"})
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 1
+      WebMock.reset_executed_requests!
+
+    end
+
+    it 'get all flags with no fallback' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+              "id": 1,
+              "name": "Beta Feature",
+              "key": "beta-feature",
+              "is_simple_flag": false,
+              "active": true,
+              "rollout_percentage": 100,
+              "filters": {
+                  "groups": [
+                      {
+                          "properties": [],
+                          "rollout_percentage": 100,
+                      }
+                  ]
+              },
+          },
+          {
+              "id": 2,
+              "name": "Beta Feature",
+              "key": "disabled-feature",
+              "is_simple_flag": false,
+              "active": true,
+              "filters": {
+                  "groups": [
+                      {
+                          "properties": [],
+                          "rollout_percentage": 0,
+                      }
+                  ]
+              },
+          },
+        ]
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+      .to_return(status: 200, body:{"featureFlags": {"beta-feature" => "variant-1", "beta-feature2" => "variant-2"}}.to_json)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      expect(c.get_all_flags("distinct-id")).to eq({"beta-feature" => true, "disabled-feature" => false})
+      assert_not_requested :post, 'https://app.posthog.com/decide/?v=2'
+
+    end
   end
 
 

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -1,0 +1,2706 @@
+require 'spec_helper'
+
+
+class PostHog
+
+  RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = nil
+
+  describe 'local evaluation' do
+    it 'evaluates person properties' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": "Beta Feature",
+            "key": "person-flag",
+            "is_simple_flag": true,
+            "active": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "region",
+                                "operator": "exact",
+                                "value": ["USA"],
+                                "type": "person",
+                            }
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ],
+            },
+          },]
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      # shouldn't call decide
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+        .to_return(status: 400)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      expect(c.get_feature_flag("person-flag", "some-distinct-id", person_properties: {"region" => "USA"})).to eq(true)
+      expect(c.get_feature_flag("person-flag", "some-distinct-id", person_properties: {"region" => "Canada"})).to eq(false)
+
+    end
+
+    it 'evaluates group properties' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": "Beta Feature",
+            "key": "group-flag",
+            "is_simple_flag": true,
+            "active": true,
+            "filters": {
+                "aggregation_group_type_index": 0,
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "group_type_index": 0,
+                                "key": "name",
+                                "operator": "exact",
+                                "value": ["Project Name 1"],
+                                "type": "group",
+                            }
+                        ],
+                        "rollout_percentage": 35,
+                    }
+                ],
+            },
+          },],
+        "group_type_mapping": {"0" => "company", "1" => "project"}
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      # shouldn't call decide
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+          .to_return(status: 200, body: {"featureFlags": {"group-flag": "decide-fallback-value"}}.to_json)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      # groups not passed in, hence false
+      expect(c.get_feature_flag("group-flag", "some-distinct-id", group_properties: {"company" => {"name" => "Project Name 1"}})).to eq(false)
+      expect(c.get_feature_flag("group-flag", "some-distinct-2", group_properties: {"company" => {"name" => "Project Name 2"}})).to eq(false)
+
+      # this is good
+      expect(c.get_feature_flag("group-flag", "some-distinct-2", groups: {"company" => "amazon_without_rollout"}, group_properties: {"company" => {"name" => "Project Name 1"}})).to eq(true)
+      
+      # rollout % not met
+      expect(c.get_feature_flag("group-flag", "some-distinct-2", groups: {"company" => "amazon"}, group_properties: {"company" => {"name" => "Project Name 1"}})).to eq(false)
+      
+      # property mismatch
+      expect(c.get_feature_flag("group-flag", "some-distinct-2", groups: {"company" => "amazon_without_rollout"}, group_properties: {"company" => {"name" => "Project Name 2"}})).to eq(false)
+
+      assert_not_requested :post, 'https://app.posthog.com/decide/?v=2'
+    end
+
+    it 'evaluates group properties and falls back to decide when group_type_mappings not present' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": "Beta Feature",
+            "key": "group-flag",
+            "is_simple_flag": true,
+            "active": true,
+            "filters": {
+                "aggregation_group_type_index": 0,
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "group_type_index": 0,
+                                "key": "name",
+                                "operator": "exact",
+                                "value": ["Project Name 1"],
+                                "type": "group",
+                            }
+                        ],
+                        "rollout_percentage": 35,
+                    }
+                ],
+            },
+          },],
+        # "group_type_mapping": {}
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+          .to_return(status: 200, body: {"featureFlags": {"group-flag": "decide-fallback-value"}}.to_json)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      # group_type_mappings not present, so fallback to `/decide`
+      expect(c.get_feature_flag("group-flag", "some-distinct-2", groups: {"company" => "amazon"}, group_properties: {"company" => {"name" => "Project Name 2"}})).to eq("decide-fallback-value")
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 1
+    end
+
+    it 'evaluates flag with complex definition' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": "Beta Feature",
+            "key": "complex-flag",
+            "is_simple_flag": false,
+            "active": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "region",
+                                "operator": "exact",
+                                "value": ["USA"],
+                                "type": "person",
+                            },
+                            {
+                                "key": "name",
+                                "operator": "exact",
+                                "value": ["Aloha"],
+                                "type": "person",
+                            },
+                        ],
+                        "rollout_percentage": 100,
+                    },
+                    {
+                        "properties": [
+                            {
+                                "key": "email",
+                                "operator": "exact",
+                                "value": ["a@b.com", "b@c.com"],
+                                "type": "person",
+                            },
+                        ],
+                        "rollout_percentage": 30,
+                    },
+                    {
+                        "properties": [
+                            {
+                                "key": "doesnt_matter",
+                                "operator": "exact",
+                                "value": ["1", "2"],
+                                "type": "person",
+                            },
+                        ],
+                        "rollout_percentage": 0,
+                    },
+                ],
+            }
+        },]
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+      .to_return(status: 200, body: {"featureFlags": {"complex-flag": "decide-fallback-value"}}.to_json)
+
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      expect(c.get_feature_flag("complex-flag", "some-distinct-id", person_properties: {"region" => "USA", "name" => "Aloha"})).to eq(true)
+      assert_not_requested :post, 'https://app.posthog.com/decide/?v=2'
+      
+      
+      # this distinctIDs hash is < rollout %
+      expect(c.get_feature_flag("complex-flag", "some-distinct-id_within_rollout?", person_properties: {"region" => "USA", "email" => "a@b.com"})).to eq(true)
+      assert_not_requested :post, 'https://app.posthog.com/decide/?v=2'
+      
+      # will fall back on `/decide`, as all properties present for second group, but that group resolves to false
+      expect(c.get_feature_flag("complex-flag", "some-distinct-id_outside_rollout?", person_properties: {"region" => "USA", "email" => "a@b.com"})).to eq("decide-fallback-value")
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 1
+      
+      WebMock.reset_executed_requests!
+      
+      # same as above
+      expect(c.get_feature_flag("complex-flag", "some-distinct-id", person_properties: {"doesnt_matter" => "1"})).to eq("decide-fallback-value")
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 1
+      WebMock.reset_executed_requests!
+      
+      # 
+      expect(c.get_feature_flag("complex-flag", "some-distinct-id", person_properties: {"region" => "USA"})).to eq("decide-fallback-value")
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 1
+      WebMock.reset_executed_requests!
+      
+      # won't need to fallback when all values are present, and resolves to False
+      expect(c.get_feature_flag("complex-flag", "some-distinct-id_outside_rollout?", person_properties: {"region" => "USA", "email" => "a@b.com", "name" => "X", "doesnt_matter" => "1"})).to eq(false)
+      assert_not_requested :post, 'https://app.posthog.com/decide/?v=2'
+    end
+
+    it 'falls back to decide' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": "Beta Feature",
+            "key": "beta-feature",
+            "active": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [{"key": "id", "value": 98, "operator": nil, "type": "cohort"}],
+                        "rollout_percentage": 100,
+                    }
+                ],
+            },
+          },
+          {
+            "id": 2,
+            "name": "Beta Feature",
+            "key": "beta-feature2",
+            "active": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [
+                            {
+                                "key": "region",
+                                "operator": "exact",
+                                "value": ["USA"],
+                                "type": "person",
+                            }
+                        ],
+                        "rollout_percentage": 100,
+                    }
+                ],
+            },
+          },
+        ]
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+      .to_return(status: 200, body: {"featureFlags": {"beta-feature": "alakazam", "beta-feature2": "alakazam2"}}.to_json)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      # beta-feature fallbacks to decide because property type is unknown
+      expect(c.get_feature_flag("beta-feature", "some-distinct-id")).to eq("alakazam")
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 1
+      WebMock.reset_executed_requests!
+
+      # beta-feature2 fallbacks to decide because region property not given with call
+      expect(c.get_feature_flag("beta-feature2", "some-distinct-id")).to eq("alakazam2")
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 1
+      WebMock.reset_executed_requests!
+
+    end
+
+    it 'defaults dont hinder regular evaluation' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": "Beta Feature",
+            "key": "beta-feature",
+            "is_simple_flag": true,
+            "active": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 0,
+                    }
+                ],
+            },
+          },
+        ]
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+      .to_return(status: 200, body: {"featureFlags": {}}.to_json)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      # beta-feature resolves to False, so no matter the default, stays False
+      expect(c.get_feature_flag("beta-feature", "some-distinct-id", true)).to be_falsey
+      expect(c.get_feature_flag("beta-feature", "some-distinct-id", false)).to be_falsey
+      assert_not_requested :post, 'https://app.posthog.com/decide/?v=2'
+
+      # beta-feature2 falls back to decide, and whatever decide returns is the value
+      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", true)).to be_falsey
+      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", false)).to be_falsey
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 2
+      WebMock.reset_executed_requests!
+    end
+
+    it 'defaults come into play when decide errors out' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": "Beta Feature",
+            "key": "beta-feature",
+            "is_simple_flag": true,
+            "active": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 0,
+                    }
+                ],
+            },
+          },
+        ]
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+      .to_return(status: 400, body: {"error": "went wrong!"}.to_json)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      # beta-feature2 falls back to decide, which on error returns default
+      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", true)).to be(true)
+      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", 'xyz')).to eq('xyz')
+      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", false)).to eq(false)
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 3
+      WebMock.reset_executed_requests!
+    end
+
+    it 'experience continuity is not evaluated locally' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": "Beta Feature",
+            "key": "beta-feature",
+            "is_simple_flag": true,
+            "active": true,
+            "ensure_experience_continuity": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 0,
+                    }
+                ],
+            },
+          },
+        ]
+      }
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+      .to_return(status: 200, body: {"featureFlags": {"beta-feature": "decide-fallback-value"}}.to_json)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      # beta-feature2 falls back to decide, which on error returns default
+      expect(c.get_feature_flag("beta-feature", "some-distinct-id")).to eq("decide-fallback-value")
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 1
+    end
+
+    # TODO: 3 tests for get_all_flags
+  end
+
+
+  describe 'property matching' do
+    it 'with operator exact' do
+        property_a = { 'key' => 'key', 'value' => 'value' }
+
+        expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value' })).to be true
+
+        expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value2' })).to be false
+        expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '' })).to be false
+        expect(FeatureFlagsPoller.match_property(property_a, { 'key' => nil })).to be false
+        
+        expect { FeatureFlagsPoller.match_property(property_a, { 'key2' => 'value' }) }.to raise_error(InconclusiveMatchError)
+        expect { FeatureFlagsPoller.match_property(property_a, {}) }.to raise_error(InconclusiveMatchError)
+
+        property_b = { 'key' => 'key', 'value' => 'value' , 'operator' => 'exact'}
+
+        expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'value' })).to be true
+        expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'value2' })).to be false
+
+        property_c = { 'key' => 'key', 'value' => ["value1", "value2", "value3"] , 'operator' => 'exact'}
+        expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value1' })).to be true
+        expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value2' })).to be true
+        expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value3' })).to be true
+
+        expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value4' })).to be false
+
+        expect { FeatureFlagsPoller.match_property(property_c, { 'key2' => 'value' }) }.to raise_error(InconclusiveMatchError)
+
+    end
+
+    it 'with operator is_not' do
+      property_a = { 'key' => 'key', 'value' => 'value', 'operator' => 'is_not' }
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value2' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => nil })).to be true
+      
+      expect { FeatureFlagsPoller.match_property(property_a, { 'key2' => 'value' }) }.to raise_error(InconclusiveMatchError)
+      expect { FeatureFlagsPoller.match_property(property_a, {}) }.to raise_error(InconclusiveMatchError)
+
+
+      property_c = { 'key' => 'key', 'value' => ["value1", "value2", "value3"] , 'operator' => 'is_not'}
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value1' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value2' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value3' })).to be false
+
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value4' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value5' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => '' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => nil })).to be true
+
+
+      expect { FeatureFlagsPoller.match_property(property_c, { 'key2' => 'value' }) }.to raise_error(InconclusiveMatchError)
+
+    end
+
+    it 'with operator is_set' do
+      property_a = { 'key' => 'key', 'value' => 'is_set', 'operator' => 'is_set' }
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value2' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => nil })).to be true
+      
+      expect { FeatureFlagsPoller.match_property(property_a, { 'key2' => 'value' }) }.to raise_error(InconclusiveMatchError)
+      expect { FeatureFlagsPoller.match_property(property_a, {}) }.to raise_error(InconclusiveMatchError)
+
+    end
+
+    it 'with operator icontains' do
+      property_a = { 'key' => 'key', 'value' => 'vaLuE', 'operator' => 'icontains' }
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value2' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'vaLue3' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '343tfvalUe5' })).to be true
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => nil })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 1234 })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '1234' })).to be false
+      
+      expect { FeatureFlagsPoller.match_property(property_a, { 'key2' => 'value' }) }.to raise_error(InconclusiveMatchError)
+      expect { FeatureFlagsPoller.match_property(property_a, {}) }.to raise_error(InconclusiveMatchError)
+
+      property_b = { 'key' => 'key', 'value' => '3', 'operator' => 'icontains' }
+
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => '3' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 323 })).to be true
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'val3' })).to be true
+      
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'three' })).to be false
+
+    end
+
+    it 'with operator regex' do
+      property_a = { 'key' => 'key', 'value' => '\.com$', 'operator' => 'regex' }
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value.com' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value2.com' })).to be true
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'valuecom' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value\com' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '.com343tfvalue5' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => nil })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '' })).to be false
+      
+      expect { FeatureFlagsPoller.match_property(property_a, { 'key2' => 'value' }) }.to raise_error(InconclusiveMatchError)
+      expect { FeatureFlagsPoller.match_property(property_a, {}) }.to raise_error(InconclusiveMatchError)
+
+      property_b = { 'key' => 'key', 'value' => '3', 'operator' => 'regex' }
+
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => '3' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 323 })).to be true
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'val3' })).to be true
+      
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'three' })).to be false
+
+
+      # invalid regex
+      property_c = { 'key' => 'key', 'value' => '?*', 'operator' => 'regex' }
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value.com' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value2' })).to be false
+
+      # non string value
+      property_d = { 'key' => 'key', 'value' => 4, 'operator' => 'regex' }
+      expect(FeatureFlagsPoller.match_property(property_d, { 'key' => '4' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_d, { 'key' => 4 })).to be true
+
+      expect(FeatureFlagsPoller.match_property(property_d, { 'key' => 'value' })).to be false
+
+      # non string value - not_regex
+      property_d = { 'key' => 'key', 'value' => 4, 'operator' => 'not_regex' }
+      expect(FeatureFlagsPoller.match_property(property_d, { 'key' => '4' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_d, { 'key' => 4 })).to be false
+
+      expect(FeatureFlagsPoller.match_property(property_d, { 'key' => 'value' })).to be true
+
+    end
+
+    it 'with math operators' do
+      property_a = { 'key' => 'key', 'value' => 1, 'operator' => 'gt' }
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 2 })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 3 })).to be true
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 0 })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => -1 })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => "23" })).to be false
+
+      property_b = { 'key' => 'key', 'value' => 1, 'operator' => 'lt' }
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 0 })).to be true
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => -1 })).to be true
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => -3 })).to be true
+
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => "3" })).to be false
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => "1" })).to be false
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 1 })).to be false
+
+      property_c = { 'key' => 'key', 'value' => 1, 'operator' => 'gte' }
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 2 })).to be true
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 1 })).to be true
+      
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 0 })).to be false
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => -1 })).to be false
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => -3 })).to be false
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => "3" })).to be false
+
+      property_d = { 'key' => 'key', 'value' => '43', 'operator' => 'lte' }
+      expect(FeatureFlagsPoller.match_property(property_d, { 'key' => '43' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_d, { 'key' => '42' })).to be true
+      
+      expect(FeatureFlagsPoller.match_property(property_d, { 'key' => '44' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_d, { 'key' => 44 })).to be false
+
+    end
+  end
+
+  describe 'capture calls' do
+  end
+
+  describe 'consistency tests' do
+
+    it 'is consistent for simple flags' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": '',
+            "key": 'simple-flag',
+            "active": true,
+            "is_simple_flag": false,
+            "filters": {
+                "groups": [{"properties": [], "rollout_percentage": 45}],
+            },
+          },]
+        }
+
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      # shouldn't call decide
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+        .to_return(status: 400)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      results = [
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+      ]
+
+      for i in 0..999 do
+        distinctID = "distinct_id_#{i}"
+
+        feature_flag_match = c.is_feature_enabled("simple-flag", distinctID)
+
+        if results[i]
+          expect(feature_flag_match).to be true
+        else
+          expect(feature_flag_match).to be false
+        end
+      end
+    end
+
+    it 'is consistent for multivariate flags' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": "Beta Feature",
+              "key": "multivariate-flag",
+              "is_simple_flag": false,
+              "active": true,
+              "filters": {
+                  "groups": [{"properties": [], "rollout_percentage": 55}],
+                  "multivariate": {
+                      "variants": [
+                          {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
+                          {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 20},
+                          {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 20},
+                          {"key": "fourth-variant", "name": "Fourth Variant", "rollout_percentage": 5},
+                          {"key": "fifth-variant", "name": "Fifth Variant", "rollout_percentage": 5},
+                      ],
+                  },
+              },
+          },]
+        }
+
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+      # shouldn't call decide
+      stub_request(:post, 'https://app.posthog.com/decide/?v=2')
+        .to_return(status: 400)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      results = [
+        "second-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "third-variant",
+        false,
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        "fourth-variant",
+        "first-variant",
+        false,
+        "third-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "third-variant",
+        false,
+        "third-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        "second-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        "second-variant",
+        "second-variant",
+        "third-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "second-variant",
+        "fourth-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "second-variant",
+        false,
+        "third-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        "fifth-variant",
+        false,
+        "second-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        "third-variant",
+        "third-variant",
+        false,
+        false,
+        false,
+        false,
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        "third-variant",
+        "third-variant",
+        false,
+        "third-variant",
+        "second-variant",
+        "third-variant",
+        false,
+        false,
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        "second-variant",
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        "second-variant",
+        "second-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        "third-variant",
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        "fifth-variant",
+        "second-variant",
+        false,
+        "second-variant",
+        false,
+        "first-variant",
+        "third-variant",
+        "first-variant",
+        "fifth-variant",
+        "third-variant",
+        false,
+        false,
+        "fourth-variant",
+        false,
+        false,
+        false,
+        false,
+        "third-variant",
+        false,
+        false,
+        "third-variant",
+        false,
+        "first-variant",
+        "second-variant",
+        "second-variant",
+        "second-variant",
+        false,
+        "first-variant",
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        false,
+        false,
+        "second-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "third-variant",
+        "first-variant",
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        "third-variant",
+        "third-variant",
+        false,
+        "second-variant",
+        "first-variant",
+        false,
+        "second-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        "fifth-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        "second-variant",
+        "third-variant",
+        "third-variant",
+        false,
+        "first-variant",
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        "third-variant",
+        "first-variant",
+        false,
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "second-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "second-variant",
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        "third-variant",
+        false,
+        "first-variant",
+        false,
+        "third-variant",
+        false,
+        "third-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        "third-variant",
+        "first-variant",
+        "second-variant",
+        "fifth-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        "third-variant",
+        false,
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        "third-variant",
+        false,
+        false,
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        "fourth-variant",
+        "fourth-variant",
+        "third-variant",
+        "second-variant",
+        "first-variant",
+        "third-variant",
+        "fifth-variant",
+        false,
+        "first-variant",
+        "fifth-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "second-variant",
+        "fifth-variant",
+        "second-variant",
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        false,
+        "third-variant",
+        false,
+        "second-variant",
+        "fifth-variant",
+        false,
+        "third-variant",
+        "first-variant",
+        false,
+        false,
+        "fourth-variant",
+        false,
+        false,
+        "second-variant",
+        false,
+        false,
+        "first-variant",
+        "fourth-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "third-variant",
+        "third-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        false,
+        "first-variant",
+        "third-variant",
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        "second-variant",
+        "second-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "fifth-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "second-variant",
+        "third-variant",
+        "first-variant",
+        "fourth-variant",
+        "first-variant",
+        "third-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        "third-variant",
+        false,
+        "fourth-variant",
+        "fifth-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "second-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        false,
+        "first-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        "third-variant",
+        "third-variant",
+        "first-variant",
+        false,
+        false,
+        "second-variant",
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "second-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "third-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "third-variant",
+        "third-variant",
+        false,
+        false,
+        false,
+        false,
+        "third-variant",
+        "fourth-variant",
+        "fourth-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        "first-variant",
+        false,
+        "second-variant",
+        "first-variant",
+        "third-variant",
+        false,
+        "third-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        "third-variant",
+        false,
+        false,
+        false,
+        "fourth-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        "fourth-variant",
+        false,
+        "first-variant",
+        "third-variant",
+        "first-variant",
+        false,
+        false,
+        "third-variant",
+        false,
+        "first-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        "third-variant",
+        "second-variant",
+        "fourth-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        "second-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        "first-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "third-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        "fifth-variant",
+        "fourth-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        "fourth-variant",
+        false,
+        false,
+        false,
+        "fourth-variant",
+        false,
+        false,
+        "third-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "third-variant",
+        "third-variant",
+        "second-variant",
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        "second-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        "second-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "third-variant",
+        "second-variant",
+        false,
+        false,
+        "fifth-variant",
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "second-variant",
+        "third-variant",
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        "third-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        "fourth-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "third-variant",
+        false,
+        false,
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        "second-variant",
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        "second-variant",
+        "third-variant",
+        "second-variant",
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        "second-variant",
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        false,
+        "third-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        "second-variant",
+        "third-variant",
+        "second-variant",
+        "fourth-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        false,
+        "second-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        false,
+        "second-variant",
+        false,
+        false,
+        false,
+        false,
+        "second-variant",
+        false,
+        "first-variant",
+        false,
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        "third-variant",
+        false,
+        "third-variant",
+        false,
+        false,
+        "second-variant",
+        false,
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        "second-variant",
+        false,
+        false,
+        "first-variant",
+        "third-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        "second-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "fifth-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        false,
+        "third-variant",
+        false,
+        false,
+        "second-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        "fourth-variant",
+        "second-variant",
+        "first-variant",
+        "second-variant",
+        false,
+        "second-variant",
+        false,
+        "second-variant",
+        false,
+        "first-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        "second-variant",
+        false,
+        "first-variant",
+        false,
+        "fifth-variant",
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        false,
+        "first-variant",
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        "fifth-variant",
+        false,
+        false,
+        "third-variant",
+        false,
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        "third-variant",
+        "third-variant",
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        "second-variant",
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        "fifth-variant",
+        "first-variant",
+        false,
+        false,
+        "fourth-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        "fourth-variant",
+        "first-variant",
+        false,
+        "second-variant",
+        "third-variant",
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "third-variant",
+        "third-variant",
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        "second-variant",
+        false,
+        false,
+        "second-variant",
+        false,
+        "third-variant",
+        "first-variant",
+        "second-variant",
+        "fifth-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "first-variant",
+        "fifth-variant",
+        false,
+        false,
+        false,
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        "fourth-variant",
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "second-variant",
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        "third-variant",
+        false,
+        "first-variant",
+        false,
+        "third-variant",
+        "third-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "second-variant",
+        false,
+        "second-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "second-variant",
+        false,
+        "third-variant",
+        false,
+        "first-variant",
+        "fifth-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "fourth-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "fifth-variant",
+        false,
+        false,
+        false,
+        "second-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        "second-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        "third-variant",
+        "first-variant",
+        false,
+        "second-variant",
+        false,
+        false,
+        "third-variant",
+        "second-variant",
+        "third-variant",
+        false,
+        "first-variant",
+        "third-variant",
+        "second-variant",
+        "first-variant",
+        "third-variant",
+        false,
+        false,
+        "first-variant",
+        "first-variant",
+        false,
+        false,
+        false,
+        "first-variant",
+        "third-variant",
+        "second-variant",
+        "first-variant",
+        "first-variant",
+        "first-variant",
+        false,
+        "third-variant",
+        "second-variant",
+        "third-variant",
+        false,
+        false,
+        "third-variant",
+        "first-variant",
+        false,
+        "first-variant",
+      ]
+
+      for i in 0..999 do
+        distinctID = "distinct_id_#{i}"
+
+        feature_flag_match = c.get_feature_flag("multivariate-flag", distinctID)
+
+        if results[i]
+          expect(feature_flag_match).to eq(results[i])
+        else
+          expect(feature_flag_match).to be false
+        end
+      end
+    end
+  end
+
+
+end
+

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -368,19 +368,19 @@ class PostHog
 
       # beta-feature should fallback to decide because property type is unknown
       # but doesn't because only_evaluate_locally is true
-      expect(c.get_feature_flag("beta-feature", "some-distinct-id", only_evaluate_locally: true)).to eq(nil)
-      expect(c.is_feature_enabled("beta-feature", "some-distinct-id", only_evaluate_locally: true)).to eq(false)
+      expect(c.get_feature_flag("beta-feature", "some-distinct-id", only_evaluate_locally: true)).to be(nil)
+      expect(c.is_feature_enabled("beta-feature", "some-distinct-id", only_evaluate_locally: true)).to be(nil)
       assert_not_requested :post, 'https://app.posthog.com/decide/?v=2'
 
       # beta-feature2 should fallback to decide because region property not given with call
       # but doesn't because only_evaluate_locally is true
-      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", only_evaluate_locally: true)).to eq(nil)
-      expect(c.is_feature_enabled("beta-feature2", "some-distinct-id", only_evaluate_locally: true)).to eq(false)
+      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", only_evaluate_locally: true)).to be(nil)
+      expect(c.is_feature_enabled("beta-feature2", "some-distinct-id", only_evaluate_locally: true)).to be(nil)
       assert_not_requested :post, 'https://app.posthog.com/decide/?v=2'
 
     end
 
-    it 'defaults dont hinder regular evaluation' do
+    it "doesn't return undefined when flag is evaluated successfully" do
       api_feature_flag_res = {
         "flags": [
           {
@@ -411,18 +411,18 @@ class PostHog
       c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
 
       # beta-feature resolves to False, so no matter the default, stays False
-      expect(c.get_feature_flag("beta-feature", "some-distinct-id", true)).to be_falsey
-      expect(c.get_feature_flag("beta-feature", "some-distinct-id", false)).to be_falsey
+      expect(c.get_feature_flag("beta-feature", "some-distinct-id")).to be(false)
+      expect(c.is_feature_enabled("beta-feature", "some-distinct-id")).to be(false)
       assert_not_requested :post, 'https://app.posthog.com/decide/?v=2'
 
       # beta-feature2 falls back to decide, and whatever decide returns is the value
-      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", true)).to be_falsey
-      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", false)).to be_falsey
+      expect(c.get_feature_flag("beta-feature2", "some-distinct-id")).to be(false)
+      expect(c.is_feature_enabled("beta-feature2", "some-distinct-id")).to be(false)
       assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 2
       WebMock.reset_executed_requests!
     end
 
-    it 'defaults come into play when decide errors out' do
+    it 'returns undefined when decide errors out' do
       api_feature_flag_res = {
         "flags": [
           {
@@ -453,10 +453,9 @@ class PostHog
       c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
 
       # beta-feature2 falls back to decide, which on error returns default
-      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", true)).to be(true)
-      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", 'xyz')).to eq('xyz')
-      expect(c.get_feature_flag("beta-feature2", "some-distinct-id", false)).to eq(false)
-      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 3
+      expect(c.get_feature_flag("beta-feature2", "some-distinct-id")).to be(nil)
+      expect(c.is_feature_enabled("beta-feature2", "some-distinct-id")).to be(nil)
+      assert_requested :post, 'https://app.posthog.com/decide/?v=2', times: 2
       WebMock.reset_executed_requests!
     end
 

--- a/spec/posthog/utils_spec.rb
+++ b/spec/posthog/utils_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+class PostHog
+    describe Utils do
+        it 'size limited dict works' do
+            size = 10
+            dict = PostHog::Utils::SizeLimitedHash.new(size)
+            for i in 0..100
+                dict[i] = i
+
+                expect(dict[i]).to eq(i)
+                expect(dict.length).to eq(i % size + 1)
+
+                if i % size == 0
+                    # old numbers should've been removed
+                    expect(dict[i-1]).to be_nil
+                    expect(dict[i-3]).to be_nil
+                    expect(dict[i-5]).to be_nil
+                    expect(dict[i-9]).to be_nil
+                end
+            end
+        end
+
+        it 'size limited dict works with default block generator' do
+            size = 10
+            dict = PostHog::Utils::SizeLimitedHash.new(size) { |hash, key| hash[key] = Array.new }
+            for i in 0..100
+                dict[i] << i
+
+                expect(dict[i]).to eq([i])
+                expect(dict.length <= size).to eq(true)
+
+            end
+        end
+    end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
-# https://github.com/codecov/codecov-ruby#usage
-if !ENV['GH_ACTIONS_UNIT_TESTS']
-  require 'simplecov'
-  SimpleCov.start
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-end
+# # https://github.com/codecov/codecov-ruby#usage
+# if !ENV['GH_ACTIONS_UNIT_TESTS']
+#   require 'simplecov'
+#   SimpleCov.start
+#   require 'codecov'
+#   SimpleCov.formatter = SimpleCov::Formatter::Codecov
+# end
 
 require 'posthog'
 require 'active_support/time'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 # https://github.com/codecov/codecov-ruby#usage
-if !ENV['GH_ACTIONS_UNIT_TESTS']
-  require 'simplecov'
-  SimpleCov.start
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-end
+# if !ENV['GH_ACTIONS_UNIT_TESTS']
+#   require 'simplecov'
+#   SimpleCov.start
+#   require 'codecov'
+#   SimpleCov.formatter = SimpleCov::Formatter::Codecov
+# end
 
 require 'posthog'
 require 'active_support/time'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
-# # https://github.com/codecov/codecov-ruby#usage
-# if !ENV['GH_ACTIONS_UNIT_TESTS']
-#   require 'simplecov'
-#   SimpleCov.start
-#   require 'codecov'
-#   SimpleCov.formatter = SimpleCov::Formatter::Codecov
-# end
+# https://github.com/codecov/codecov-ruby#usage
+if !ENV['GH_ACTIONS_UNIT_TESTS']
+  require 'simplecov'
+  SimpleCov.start
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
 
 require 'posthog'
 require 'active_support/time'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 # https://github.com/codecov/codecov-ruby#usage
-# if !ENV['GH_ACTIONS_UNIT_TESTS']
-#   require 'simplecov'
-#   SimpleCov.start
-#   require 'codecov'
-#   SimpleCov.formatter = SimpleCov::Formatter::Codecov
-# end
+if !ENV['GH_ACTIONS_UNIT_TESTS']
+  require 'simplecov'
+  SimpleCov.start
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
 
 require 'posthog'
 require 'active_support/time'


### PR DESCRIPTION
... and lots of accompanying fixes.

Follows spec from: https://github.com/PostHog/posthog/issues/10459#issuecomment-1193842228 , and is mostly a copy of https://github.com/PostHog/posthog-python/pull/68/files.

Also tagging @macobo for review, since I learned Ruby 2 days ago! (It _might_ look like a lot of code, but 3k is tests, 2k of which were generated from servers, and it felt easier to put everything in one PR, so we're sure we're not missing anything)

Start with the `changelog.md` to get a sense of changes, and then

some additional fixes to watch out for:

1. Cleans up the feature flag API requests we were making (it was very clunky, and `decide` requests weren't actually sending the payload, so this wasn't working at all)
2. Ensures that `send_feature_flags` on capture works, even without a personal API key (this was breaking for existing clients with the last change, as suddenly the personal API key became a hard requirement for `capture`, which isn't great)

TODO: 

1. [x] Add `get_all_flags`
3. [x] Handle atleast once semantics for `$feature_flag_called` events
4. [x] More tests

Testing

- Added docs for how to run example and tests.
- Tested the `example.py` works with a local installation
- Added loads of tests