### PR TITLE
Remove concurrent gem limitation

### DIFF
--- a/posthog-ruby.gemspec
+++ b/posthog-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 2.0'
   
-  spec.add_dependency "concurrent-ruby", "~> 1", "< 1.1.10"
+  spec.add_dependency "concurrent-ruby"
 
   # Used in the executable testing script
   spec.add_development_dependency 'commander', '~> 4.4'

--- a/posthog-ruby.gemspec
+++ b/posthog-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 2.0'
   
-  spec.add_dependency "concurrent-ruby"
+  spec.add_dependency 'concurrent-ruby', '~> 1'
 
   # Used in the executable testing script
   spec.add_development_dependency 'commander', '~> 4.4'


### PR DESCRIPTION
Remove concurrent gem limitation, it doesn't seem to have any deprecation warnings tied to it anymore?

https://github.com/PostHog/posthog-ruby/issues/24