### PR TITLE
fix: capture call sends active feature flags only

### DIFF
--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -91,7 +91,7 @@ class PostHog
       symbolize_keys! attrs
 
       if attrs[:send_feature_flags]
-        all_feature_variants = @feature_flags_poller._get_active_feature_variants(attrs[:distinct_id], attrs[:groups])
+        feature_variants = @feature_flags_poller._get_active_feature_variants(attrs[:distinct_id], attrs[:groups])
 
         attrs[:feature_variants] = feature_variants
       end

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -91,7 +91,8 @@ class PostHog
       symbolize_keys! attrs
 
       if attrs[:send_feature_flags]
-        feature_variants = @feature_flags_poller.get_feature_variants(attrs[:distinct_id], attrs[:groups])
+        all_feature_variants = @feature_flags_poller._get_active_feature_variants(attrs[:distinct_id], attrs[:groups])
+
         attrs[:feature_variants] = feature_variants
       end
 

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -55,6 +55,17 @@ class PostHog
       end
     end
 
+    def _get_active_feature_variants(distinct_id, groups={}, person_properties={}, group_properties={})
+      feature_variants = get_feature_variants(distinct_id, groups, person_properties, group_properties)
+      active_feature_variants = {}
+      feature_variants.each do |key, value|
+        if value != false
+          active_feature_variants[key] = value
+        end
+      end
+      active_feature_variants
+    end
+
     def get_feature_payloads(distinct_id, groups = {}, person_properties = {}, group_properties = {}, only_evaluate_locally = false)
       decide_data = get_decide(distinct_id, groups, person_properties, group_properties)
       if !decide_data.key?(:featureFlagPayloads)

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -3697,17 +3697,19 @@ class PostHog
     end
   end
 
-  it 'gets active feature flags' do
-    stub_request(
-      :get,
-      'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
-    ).to_return(status: 200, body: {}.to_json)
+  describe 'methods' do
+    it 'gets active feature flags' do
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_return(status: 200, body: {}.to_json)
 
-    stub_request(:post, decide_endpoint)
-    .to_return(status: 200, body: {"featureFlags": {"beta-feature": "random-variant", "off-feature": false, "alpha-feature": true}}.to_json)
+      stub_request(:post, decide_endpoint)
+      .to_return(status: 200, body: {"featureFlags": {"beta-feature": "random-variant", "off-feature": false, "alpha-feature": true}}.to_json)
 
-    c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
 
-    expect(c._get_active_feature_variants("distinct_id")).to eq({"beta-feature": "random-variant", "alpha-feature": true})
+      expect(c._get_active_feature_variants("distinct_id")).to eq({"beta-feature": "random-variant", "alpha-feature": true})
+    end
   end
 end

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -3696,20 +3696,4 @@ class PostHog
       assert_not_requested :post, decide_endpoint
     end
   end
-
-  describe 'methods' do
-    it 'gets active feature flags' do
-      stub_request(
-        :get,
-        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
-      ).to_return(status: 200, body: {}.to_json)
-
-      stub_request(:post, decide_endpoint)
-      .to_return(status: 200, body: {"featureFlags": {"beta-feature": "random-variant", "off-feature": false, "alpha-feature": true}}.to_json)
-
-      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
-
-      expect(c._get_active_feature_variants("distinct_id")).to eq({"beta-feature": "random-variant", "alpha-feature": true})
-    end
-  end
 end

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -3696,4 +3696,18 @@ class PostHog
       assert_not_requested :post, decide_endpoint
     end
   end
+
+  it 'gets active feature flags' do
+    stub_request(
+      :get,
+      'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+    ).to_return(status: 200, body: {}.to_json)
+
+    stub_request(:post, decide_endpoint)
+    .to_return(status: 200, body: {"featureFlags": {"beta-feature": "random-variant", "off-feature": false, "alpha-feature": true}}.to_json)
+
+    c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+    expect(c._get_active_feature_variants("distinct_id")).to eq({"beta-feature": "random-variant", "alpha-feature": true})
+  end
 end


### PR DESCRIPTION
ruby fix for https://github.com/PostHog/posthog-python/pull/89