### PR TITLE
Add personal API key as option for Posthog::Client initializer

### DIFF
--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -15,6 +15,7 @@ class PostHog
 
     # @param [Hash] opts
     # @option opts [String] :api_key Your project's api_key
+    # @option opts [String] :personal_api_key Your personal API key
     # @option opts [FixNum] :max_queue_size Maximum number of calls to be
     #   remain queued. Defaults to 10_000.
     # @option opts [Bool] :test_mode +true+ if messages should remain


### PR DESCRIPTION
Small change, found there is no mention about personal_api_key which forced me into reading gem code since it wasn't clear to me on how to pass it down (wasn't 100% sure that it actually handles it).