### PR TITLE
Fix rspec output and warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,12 @@ require 'posthog'
 require 'active_support/all'
 require 'webmock/rspec'
 
+RSpec.configure do |config|
+  config.before(:each) do
+    PostHog::Logging.logger = Logger.new('/dev/null') # Suppress all logging
+  end
+end
+
 # Setting timezone for ActiveSupport::TimeWithZone to UTC
 Time.zone = 'UTC'
 


### PR DESCRIPTION
**Note**: This requires #41 and can be rebased once that is merged.

The tests were previously outputing a ton of stuff from the logger. I've silenced the logger. Additionally, I've fixed deprecation warnings.