### PR TITLE
Fix memory leak in PostHog::Client.new

### DIFF
--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -52,8 +52,6 @@ class PostHog
         )
       
       @distinct_id_has_sent_flag_calls = SizeLimitedHash.new(Defaults::MAX_HASH_SIZE) { |hash, key| hash[key] = Array.new }
-
-      at_exit { @worker_thread && @worker_thread[:should_exit] = true }
     end
 
     # Synchronously waits until the worker has cleared the queue.


### PR DESCRIPTION
The PostHog::Client calls Kernel#at_exit at each instantiation, which registers a process-global callback for each Client instance. This global callback is represented by a T_FILE entry in ObjectSpace.count_objects and is never GC'd for the life of the process.

Any process that instantiates multiple clients will be susceptible to this memory leak, which is very common in almost any long-running process, but in particular, the norm for Sidekiq / Resque environments. 

The good news is this line is completely unnecessary, since in the current implementation, the worker thread does not block the process from exiting, which means that setting this thread variable is unlikely to actually cause the thread to "gracefully exit" unless the code also blocked on Thread execution via Thread#join. In other words, because Thread#join is not used, this line is a no-op. This is all mostly irrelevant anyway, since there is no actual cleanup that is not already being performed by the basic exiting of a process, and an at_exit callback (or graceful exit logic) is simply not needed for HTTP clients.

To reproduce the leak:

```ruby
GC.disable
p ObjectSpace.count_objects[:T_FILE]
10.times { PostHog::Client.new; GC.start }
p ObjectSpace.count_objects[:T_FILE]
```

This fix will likely improve use cases for users in #10.