### PR TITLE
fix(flags): Add appropriate timeouts, fix some other misc things

### DIFF
--- a/lib/posthog/defaults.rb
+++ b/lib/posthog/defaults.rb
@@ -16,6 +16,10 @@ class PostHog
       RETRIES = 10
     end
 
+    module FeatureFlags
+      FLAG_REQUEST_TIMEOUT_SECONDS = 3
+    end
+    
     module Queue
       MAX_SIZE = 10_000
     end

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -162,6 +162,10 @@ class PostHog
       if fallback_to_decide && !only_evaluate_locally
         begin
           flags_and_payloads = get_decide(distinct_id, groups, person_properties, group_properties)
+
+          if !flags_and_payloads.key?(:featureFlags)
+            raise StandardError.new("Error flags response: #{flags_and_payloads}")
+          end
           flags = stringify_keys(flags_and_payloads[:featureFlags] || {})
           payloads = stringify_keys(flags_and_payloads[:featureFlagPayloads] || {})
         rescue StandardError => e

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -137,10 +137,14 @@ class PostHog
 
         if send_feature_flags
           feature_variants = fields[:feature_variants]
+          active_feature_variants = {}
           feature_variants.each do |key, value|
             parsed[:properties]["$feature/#{key}"] = value
+            if value != false
+              active_feature_variants[key] = value
+            end
           end
-          parsed[:properties]["$active_feature_flags"] = feature_variants.keys
+          parsed[:properties]["$active_feature_flags"] = active_feature_variants.keys
         end
         parsed
       end

--- a/posthog-ruby.gemspec
+++ b/posthog-ruby.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   if RUBY_VERSION >= '2.1'
     spec.add_development_dependency 'rubocop', '~> 0.51.0'
   end
-  spec.add_development_dependency 'codecov', '~> 0.1.4'
+  spec.add_development_dependency 'codecov', '~> 0.6.0'
 end

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -452,7 +452,7 @@ class PostHog
       stub_request(:post, decide_endpoint)
       .to_return(status: 400, body: {"error": "went wrong!"}.to_json)
 
-      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true, on_error: Proc.new { |status, body| print "error: #{status}, #{body}" })
 
       # beta-feature2 falls back to decide, which on error returns default
       expect(c.get_feature_flag("beta-feature2", "some-distinct-id")).to be(nil)

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -400,6 +400,21 @@ class PostHog
                 ],
             },
           },
+          {
+            "id": 2,
+            "name": "Beta Feature2",
+            "key": "beta-feature2",
+            "is_simple_flag": false,
+            "active": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [{"key": "region", "value": "US", "operator": "exact", "type": "person"}],
+                        "rollout_percentage": 100,
+                    }
+                ],
+            },
+          },
         ]
       }
       stub_request(
@@ -442,8 +457,24 @@ class PostHog
                 ],
             },
           },
+          {
+            "id": 2,
+            "name": "Beta Feature2",
+            "key": "beta-feature2",
+            "is_simple_flag": false,
+            "active": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [{"key": "region", "value": "US", "operator": "exact", "type": "person"}],
+                        "rollout_percentage": 100,
+                    }
+                ],
+            },
+          },
         ]
       }
+      # We don't go to decide if local eval is enabled and the flag is not in list of all flag definitions
       stub_request(
         :get,
         'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
@@ -3845,7 +3876,7 @@ class PostHog
         'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
       ).to_return(status: 200, body: {"flags": []}.to_json)
       stub_request(:post, decide_endpoint)
-        .to_return(status: 200, body:{"featureFlagPayloads": {"person-flag" => 300}}.to_json)
+        .to_return(status: 200, body:{"featureFlags": {}, "featureFlagPayloads": {"person-flag" => 300}}.to_json)
       c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
       expect(c.get_feature_flag_payload("person-flag", "some-distinct-id", person_properties: {"region": "USA"})).to eq(300)
       expect(c.get_feature_flag_payload("person-flag", "some-distinct-id", match_value: true, person_properties: {"region": "USA"})).to eq(300)

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -492,6 +492,68 @@ class PostHog
       WebMock.reset_executed_requests!
     end
 
+    it 'returns undefined when decide or local_eval times out' do
+      api_feature_flag_res = {
+        "flags": [
+          {
+            "id": 1,
+            "name": "Beta Feature",
+            "key": "beta-feature",
+            "is_simple_flag": true,
+            "active": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 0,
+                    }
+                ],
+            },
+          },
+          {
+            "id": 2,
+            "name": "Beta Feature2",
+            "key": "beta-feature2",
+            "is_simple_flag": false,
+            "active": true,
+            "filters": {
+                "groups": [
+                    {
+                        "properties": [{"key": "region", "value": "US", "operator": "exact", "type": "person"}],
+                        "rollout_percentage": 100,
+                    }
+                ],
+            },
+          },
+        ]
+      }
+      # TRICKY: Pretty hard to simulate a timeout using sleep with WebMock, so we'll just raise an error
+      stub_request(
+        :get,
+        'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret'
+      ).to_raise(Net::ReadTimeout)
+
+      stub_request(:post, decide_endpoint)
+      .to_raise(Net::ReadTimeout)
+
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+      # beta-feature falls back to decide, which on error returns default
+      expect(c.get_feature_flag("beta-feature", "some-distinct-id")).to be(nil)
+      assert_requested :post, decide_endpoint, times: 1
+      WebMock.reset_executed_requests!
+
+      # beta-feature2 falls back to decide, which on error returns default
+      expect(c.get_feature_flag("beta-feature2", "some-distinct-id")).to be(nil)
+      expect(c.is_feature_enabled("beta-feature2", "some-distinct-id")).to be(nil)
+      assert_requested :post, decide_endpoint, times: 2
+      WebMock.reset_executed_requests!
+
+      expect(c.get_all_flags("some-distinct-id")).to eq({})
+      assert_requested :post, decide_endpoint, times: 1
+      WebMock.reset_executed_requests!
+    end
+
     it 'experience continuity flags are not evaluated locally' do
       api_feature_flag_res = {
         "flags": [


### PR DESCRIPTION
This PR does a few things:

1. Add a `feature_flag_request_timeout_seconds` configuration option, defaulting to 3s to control flag timeouts
2. Gets rid of a lot of error spew, instead allows passing in an on_error proc so users can decide what to do with errors
3. Unifies calling sites such that everything doesn't call the `/decide` endpoint directly, but via `get_all_flags_and_payloads` which in turn does all necessary error handling. Before this, getting payloads would always throw :/
4. Noticed as a result of above^ that we were sometimes inefficiently going to decide. The test updates where I add a second feature flag key for `beta-feature2` reflect that, since previously this would go to decide, but now it wouldn't, which is infact the ideal thing to do. (and thus to test the old flow we need an extra flag that is present but can't be locally evaluated).

Noticed while doing this that the above problem exist in posthog-python as well, will update that too