### PR TITLE
feat(groups): allow optional distinct_id for group identify calls

### DIFF
--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -119,6 +119,7 @@ class PostHog
     # @option attrs [String] :group_type Group type
     # @option attrs [String] :group_key Group key
     # @option attrs [Hash] :properties Group properties (optional)
+    # @option attrs [String] :distinct_id Distinct ID (optional)
     # @macro common_attrs
     def group_identify(attrs)
       symbolize_keys! attrs

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -64,8 +64,7 @@ class PostHog
         check_presence!(group_key, 'group_key')
         check_is_hash!(properties, 'properties')
 
-        distinct_id = "$#{group_type}_#{group_key}"
-        fields[:distinct_id] = distinct_id
+        fields[:distinct_id] ||= "$#{group_type}_#{group_key}"
         common = parse_common_fields(fields)
 
         isoify_dates! properties

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -451,8 +451,7 @@ class PostHog
         expect { client.group_identify({}) }.to raise_error(ArgumentError)
       end
 
-      it 'group identifies' do
-        properties =
+      it 'identifies group with unique id' do
         client.group_identify(
           {
             group_type: "organization",
@@ -465,6 +464,25 @@ class PostHog
         msg = client.dequeue_last_message
 
         expect(msg[:distinct_id]).to eq("$organization_id:5")
+        expect(msg[:event]).to eq("$groupidentify")
+        expect(msg[:properties][:$group_type]).to eq("organization")
+        expect(msg[:properties][:$group_set][:trait]).to eq("value")
+      end
+
+      it 'allows passing optional distinct_id to identify group' do
+        client.group_identify(
+          {
+            group_type: "organization",
+            group_key: "id:5",
+            properties: {
+              trait: "value"
+            },
+            distinct_id: '123'
+          }
+        )
+        msg = client.dequeue_last_message
+
+        expect(msg[:distinct_id]).to eq("123")
         expect(msg[:event]).to eq("$groupidentify")
         expect(msg[:properties][:$group_type]).to eq("organization")
         expect(msg[:properties][:$group_set][:trait]).to eq("value")


### PR DESCRIPTION
Adds support for an optional distinct_id param to group_identify.

See https://github.com/PostHog/posthog.com/pull/10156.