### PR TITLE
Remove rogue shell command

### DIFF
--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -553,7 +553,7 @@ class PostHog
     end
 
     def _request(uri, request_object, timeout = nil)
-      request_object['User-Agent'] = `"posthog-ruby#{PostHog::VERSION}"`
+      request_object['User-Agent'] = "posthog-ruby#{PostHog::VERSION}"
       request_timeout = timeout || 10
 
       begin

--- a/lib/posthog/version.rb
+++ b/lib/posthog/version.rb
@@ -1,3 +1,3 @@
 class PostHog
-  VERSION = '2.7.1'
+  VERSION = '2.7.2'
 end


### PR DESCRIPTION
I started noticing `posthog-ruby2.7.1: not found` in my logs after recently upgrading which I traced back to this line. In ruby \` invokes a shell command.