### PR TITLE
Fix failing test and some other local dev cleanup.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       RAILS_ENV: test
       GH_ACTIONS_UNIT_TESTS: 1
+      RUN_SIMPLECOV: 0
 
     steps:
       - uses: actions/checkout@v4

--- a/.vscode/.rspec
+++ b/.vscode/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format documentation
+--color 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "rubyTestExplorer.rspecCommand": "bundle exec rspec",
+    "rubyTestExplorer.logpanel": true,
+    "testExplorer.useNativeTesting": false,
+    "rubyTestExplorer.debugCommand": "bundle exec rspec",
+    "rubyTestExplorer.env": {
+        "RUBY_TEST_ADAPTER_DRY_RUN": "1",
+        "RUBY_TEST_ADAPTER": "1"
+    },
+    "rubyTestExplorer.rspecConfigFile": ".vscode/.rspec",
+    "rubyTestExplorer.testFramework": "rspec"
+}

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -4147,7 +4147,7 @@ class PostHog
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Content-Type'=>'application/json',
             'Host'=>'app.posthog.com',
-            'User-Agent'=>''
+            'User-Agent'=>"posthog-ruby#{PostHog::VERSION}"
           }).
         to_return(status: 200, body: "{\"featureFlags\": {}}", headers: {})
 

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -493,40 +493,6 @@ class PostHog
     end
 
     it 'returns undefined when decide or local_eval times out' do
-      api_feature_flag_res = {
-        "flags": [
-          {
-            "id": 1,
-            "name": "Beta Feature",
-            "key": "beta-feature",
-            "is_simple_flag": true,
-            "active": true,
-            "filters": {
-                "groups": [
-                    {
-                        "properties": [],
-                        "rollout_percentage": 0,
-                    }
-                ],
-            },
-          },
-          {
-            "id": 2,
-            "name": "Beta Feature2",
-            "key": "beta-feature2",
-            "is_simple_flag": false,
-            "active": true,
-            "filters": {
-                "groups": [
-                    {
-                        "properties": [{"key": "region", "value": "US", "operator": "exact", "type": "person"}],
-                        "rollout_percentage": 100,
-                    }
-                ],
-            },
-          },
-        ]
-      }
       # TRICKY: Pretty hard to simulate a timeout using sleep with WebMock, so we'll just raise an error
       stub_request(
         :get,

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -483,7 +483,7 @@ class PostHog
       stub_request(:post, decide_endpoint)
       .to_return(status: 400, body: {"error": "went wrong!"}.to_json)
 
-      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true, on_error: Proc.new { |status, body| print "error: #{status}, #{body}" })
+      c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
 
       # beta-feature2 falls back to decide, which on error returns default
       expect(c.get_feature_flag("beta-feature2", "some-distinct-id")).to be(nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # https://github.com/codecov/codecov-ruby#usage
-if ENV['GH_ACTIONS_UNIT_TESTS']
+if ENV['RUN_SIMPLECOV'] == '1'
   # Only load SimpleCov in CI
   require 'simplecov'
   SimpleCov.start

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # https://github.com/codecov/codecov-ruby#usage
-if !ENV['GH_ACTIONS_UNIT_TESTS']
+if ENV['GH_ACTIONS_UNIT_TESTS']
+  # Only load SimpleCov in CI
   require 'simplecov'
   SimpleCov.start
   require 'codecov'


### PR DESCRIPTION
This fixes a unit test that was failing due to sending the wrong header in the mocked request.

Other changes make developing on this project a little better. For example, Ruby LSP with Ruby Test Explorer was having issues because when it tries to discover tests and do a dry run, SimpleCov was trying to send results to the server. For whatever reason, the guards to ensure we were not in a dry run were not working. I changed it to check if we're in CI.

Also suppressed output in a test that was spewing out a lot of console output when running tests.