### PR TITLE
chore(flags): Add request id, version, id, and reason to `$feature_flag_called` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.7.3 – 2025-04-03
+## 2.7.3 – 2025-04-07
 
 1. Add more information to `$feature_flag_called` events for `/decide` requests such as flag id, version, reason, and the request id.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.7.3 – 2025-04-03
+
+1. Add more information to `$feature_flag_called` events for `/decide` requests such as flag id, version, reason, and the request id.
+
 ## 2.7.2 – 2025-03-14
 
 1. Fix invocation of shell by ` character

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.7.3 – 2025-04-07
+## 2.8.0 – 2025-04-07
 
 1. Add more information to `$feature_flag_called` events for `/decide` requests such as flag id, version, reason, and the request id.
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Specifically, the [Ruby integration](https://posthog.com/docs/integrations/ruby-
 
 ## Testing
 
-1. Run `bundle exec rspec`
-2. An example of running specific tests: `bundle exec rspec spec/posthog/client_spec.rb:26`
+1. Run `bin/test` (this ends up calling `bundle exec rspec`)
+2. An example of running specific tests: `bin/test spec/posthog/client_spec.rb:26`
 
 ## Questions?
 

--- a/bin/helpers/_utils.sh
+++ b/bin/helpers/_utils.sh
@@ -1,0 +1,15 @@
+error() {
+    echo "$@" >&2
+}
+
+fatal() {
+    error "$@"
+    exit 1
+}
+
+set_source_and_root_dir() {
+    { set +x; } 2>/dev/null
+    source_dir="$( cd -P "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+    root_dir=$(cd $source_dir && cd ../ && pwd)
+    cd $root_dir
+}

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#/ Usage: bin/test [<configuration>]
+#/ Description: Runs all the rspec tests.
+source bin/helpers/_utils.sh
+set_source_and_root_dir
+
+bundle exec rspec

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -233,6 +233,10 @@ class PostHog
     end
 
     # Returns all flags and payloads for a given user
+    # 
+    # @return [Hash] A hash with the following keys:
+    #   featureFlags: A hash of feature flags
+    #   featureFlagPayloads: A hash of feature flag payloads
     #
     # @param [String] distinct_id The distinct id of the user
     # @option [Hash] groups
@@ -242,7 +246,9 @@ class PostHog
     #
     def get_all_flags_and_payloads(distinct_id, groups: {}, person_properties: {}, group_properties: {}, only_evaluate_locally: false)
       person_properties, group_properties = add_local_person_and_group_properties(distinct_id, groups, person_properties, group_properties)
-      @feature_flags_poller.get_all_flags_and_payloads(distinct_id, groups, person_properties, group_properties, only_evaluate_locally)
+      response = @feature_flags_poller.get_all_flags_and_payloads(distinct_id, groups, person_properties, group_properties, only_evaluate_locally)
+      response.delete(:requestId) # remove internal information.
+      response
     end
 
     def reload_feature_flags

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -183,7 +183,7 @@ class PostHog
     # ```
     def get_feature_flag(key, distinct_id, groups: {}, person_properties: {}, group_properties: {}, only_evaluate_locally: false, send_feature_flag_events: true)
       person_properties, group_properties = add_local_person_and_group_properties(distinct_id, groups, person_properties, group_properties)
-      feature_flag_response, flag_was_locally_evaluated = @feature_flags_poller.get_feature_flag(key, distinct_id, groups, person_properties, group_properties, only_evaluate_locally)
+      feature_flag_response, flag_was_locally_evaluated, request_id = @feature_flags_poller.get_feature_flag(key, distinct_id, groups, person_properties, group_properties, only_evaluate_locally)
 
       feature_flag_reported_key = "#{key}_#{feature_flag_response}"
       if !@distinct_id_has_sent_flag_calls[distinct_id].include?(feature_flag_reported_key) && send_feature_flag_events
@@ -195,7 +195,7 @@ class PostHog
               '$feature_flag' => key,
               '$feature_flag_response' => feature_flag_response,
               'locally_evaluated' => flag_was_locally_evaluated
-            },
+            }.merge(request_id ? {'$feature_flag_request_id' => request_id} : {}),
             'groups': groups,
           }
         )

--- a/lib/posthog/feature_flag.rb
+++ b/lib/posthog/feature_flag.rb
@@ -1,0 +1,58 @@
+# Represents a feature flag returned by /decide v4
+class FeatureFlag
+  attr_reader :key, :enabled, :variant, :reason, :metadata
+
+  def initialize(json)
+    @key = json["key"]
+    @enabled = json["enabled"]
+    @variant = json["variant"]
+    @reason = json["reason"] ? EvaluationReason.new(json["reason"]) : nil
+    @metadata = json["metadata"] ? Metadata.new(json["metadata"].transform_keys(&:to_s)) : nil
+  end
+
+  def get_value
+    @variant || @enabled
+  end
+
+  def payload
+    @metadata&.payload
+  end
+
+  def self.from_value_and_payload(key, value, payload)
+    new({
+      "key" => key,
+      "enabled" => value.is_a?(String) ? true : value,
+      "variant" => value.is_a?(String) ? value : nil,
+      "reason" => nil,
+      "metadata" => {
+        "id" => nil,
+        "version" => nil,
+        "payload" => payload,
+        "description" => nil
+      }
+    })
+  end
+end
+
+# Represents the reason why a flag was enabled/disabled
+class EvaluationReason
+  attr_reader :code, :description, :condition_index
+
+  def initialize(json)
+    @code = json["code"]
+    @description = json["description"]
+    @condition_index = json["condition_index"]
+  end
+end
+
+# Represents metadata about a feature flag
+class Metadata
+  attr_reader :id, :version, :payload, :description
+
+  def initialize(json)
+    @id = json["id"]
+    @version = json["version"]
+    @payload = json["payload"]
+    @description = json["description"]
+  end
+end

--- a/lib/posthog/feature_flag.rb
+++ b/lib/posthog/feature_flag.rb
@@ -3,11 +3,12 @@ class FeatureFlag
   attr_reader :key, :enabled, :variant, :reason, :metadata
 
   def initialize(json)
+    json.transform_keys!(&:to_s)
     @key = json["key"]
     @enabled = json["enabled"]
     @variant = json["variant"]
     @reason = json["reason"] ? EvaluationReason.new(json["reason"]) : nil
-    @metadata = json["metadata"] ? Metadata.new(json["metadata"].transform_keys(&:to_s)) : nil
+    @metadata = json["metadata"] ? FeatureFlagMetadata.new(json["metadata"].transform_keys(&:to_s)) : nil
   end
 
   def get_value
@@ -39,6 +40,7 @@ class EvaluationReason
   attr_reader :code, :description, :condition_index
 
   def initialize(json)
+    json.transform_keys!(&:to_s)
     @code = json["code"]
     @description = json["description"]
     @condition_index = json["condition_index"]
@@ -46,10 +48,11 @@ class EvaluationReason
 end
 
 # Represents metadata about a feature flag
-class Metadata
+class FeatureFlagMetadata
   attr_reader :id, :version, :payload, :description
 
   def initialize(json)
+    json.transform_keys!(&:to_s)
     @id = json["id"]
     @version = json["version"]
     @payload = json["payload"]

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -77,7 +77,7 @@ class PostHog
         "group_properties": group_properties,
       }
 
-      decide_data = _request_feature_flag_evaluation(request_data)
+      _request_feature_flag_evaluation(request_data)
     end
 
     def get_remote_config_payload(flag_key)

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -566,7 +566,7 @@ class PostHog
     end
 
     def _request_feature_flag_evaluation(data={})
-      uri = URI("#{@host}/decide/?v=3")
+      uri = URI("#{@host}/decide/?v=4")
       req = Net::HTTP::Post.new(uri)
       req['Content-Type'] = 'application/json'
       data['token'] = @project_api_key

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -140,7 +140,14 @@ class PostHog
 
       if !flag_was_locally_evaluated && !only_evaluate_locally
         begin
-          flags = get_feature_variants(distinct_id, groups, person_properties, group_properties, true)
+          decide_data = get_all_flags_and_payloads(distinct_id, groups, person_properties, group_properties, false, true)
+          if !decide_data.key?(:featureFlags)
+            logger.debug "Missing feature flags key: #{decide_data.to_json}"
+            flags = {}
+          else
+            flags =stringify_keys(decide_data[:featureFlags] || {})
+          end
+
           response = flags[key]
           if response.nil?
             response = false

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -148,7 +148,7 @@ class PostHog
             logger.debug "Missing feature flags key: #{decide_data.to_json}"
             flags = {}
           else
-            flags =stringify_keys(decide_data[:featureFlags] || {})
+            flags = stringify_keys(decide_data[:featureFlags] || {})
             request_id = decide_data[:requestId]
           end
 

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -170,6 +170,7 @@ class PostHog
       flags = {}
       payloads = {}
       fallback_to_decide = @feature_flags.empty?
+      request_id = nil # Only for /decide requests
 
       @feature_flags.each do |flag|
         begin
@@ -202,13 +203,14 @@ class PostHog
           else
             flags = stringify_keys(flags_and_payloads[:featureFlags] || {})
             payloads = stringify_keys(flags_and_payloads[:featureFlagPayloads] || {})
+            request_id = flags_and_payloads[:requestId]
           end
         rescue StandardError => e
           @on_error.call(-1, "Error computing flag remotely: #{e}")
           raise if raise_on_error
         end
       end
-      {"featureFlags": flags, "featureFlagPayloads": payloads}
+      {"featureFlags": flags, "featureFlagPayloads": payloads, "requestId": request_id}
     end
 
     def get_feature_flag_payload(key, distinct_id, match_value = nil, groups = {}, person_properties = {}, group_properties = {}, only_evaluate_locally = false)

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -138,6 +138,8 @@ class PostHog
 
       flag_was_locally_evaluated = !response.nil?
 
+      request_id = nil
+
       if !flag_was_locally_evaluated && !only_evaluate_locally
         begin
           decide_data = get_all_flags_and_payloads(distinct_id, groups, person_properties, group_properties, false, true)
@@ -146,6 +148,7 @@ class PostHog
             flags = {}
           else
             flags =stringify_keys(decide_data[:featureFlags] || {})
+            request_id = decide_data[:requestId]
           end
 
           response = flags[key]
@@ -158,7 +161,7 @@ class PostHog
         end
       end
 
-      [response, flag_was_locally_evaluated]
+      [response, flag_was_locally_evaluated, request_id]
     end
 
     def get_all_flags(distinct_id, groups = {}, person_properties = {}, group_properties = {}, only_evaluate_locally = false)

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -161,7 +161,7 @@ class PostHog
       end
       # returns a string hash of all flags
       response = get_all_flags_and_payloads(distinct_id, groups, person_properties, group_properties, only_evaluate_locally)
-      flags = response[:featureFlags]
+      response[:featureFlags]
     end
 
     def get_all_flags_and_payloads(distinct_id, groups = {}, person_properties = {}, group_properties = {}, only_evaluate_locally = false, raise_on_error = false)

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -83,9 +83,10 @@ class PostHog
       # Only normalize if we have flags in the response
       if decide_response[:flags]
         #v4 format
-        flags_hash = decide_response[:flags].transform_keys(&:to_s).transform_values do |flag|
-          FeatureFlag.new(flag.transform_keys(&:to_s))
+        flags_hash = decide_response[:flags].transform_values do |flag|
+          FeatureFlag.new(flag)
         end
+        decide_response[:flags] = flags_hash
         decide_response[:featureFlags] = flags_hash.transform_values(&:get_value).transform_keys(&:to_sym)
         decide_response[:featureFlagPayloads] = flags_hash.transform_values(&:payload).transform_keys(&:to_sym)
       elsif decide_response[:featureFlags]

--- a/lib/posthog/version.rb
+++ b/lib/posthog/version.rb
@@ -1,3 +1,3 @@
 class PostHog
-  VERSION = '2.7.2'
+  VERSION = '2.7.3'
 end

--- a/lib/posthog/version.rb
+++ b/lib/posthog/version.rb
@@ -1,3 +1,3 @@
 class PostHog
-  VERSION = '2.7.3'
+  VERSION = '2.8.0'
 end

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 class PostHog
 
-  decide_endpoint = 'https://app.posthog.com/decide/?v=3'
+  decide_endpoint = 'https://app.posthog.com/decide/?v=4'
 
   RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = nil
 

--- a/spec/posthog/decide_spec.rb
+++ b/spec/posthog/decide_spec.rb
@@ -3,7 +3,7 @@ require 'posthog/client'
 
 class PostHog
   describe 'FeatureFlagsPoller#get_decide' do
-    let(:decide_endpoint) { 'https://app.posthog.com/decide/?v=3' }
+    let(:decide_endpoint) { 'https://app.posthog.com/decide/?v=4' }
     let(:feature_flag_endpoint) { 'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret' }
     let(:client) { Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true) }
     let(:poller) { client.instance_variable_get(:@feature_flags_poller) }
@@ -325,7 +325,7 @@ class PostHog
 
   describe 'Client#get_feature_flag' do
     let(:client) { Client.new(api_key: API_KEY, personal_api_key: nil, test_mode: true) }
-    let(:decide_endpoint) { 'https://app.posthog.com/decide/?v=3' }
+    let(:decide_endpoint) { 'https://app.posthog.com/decide/?v=4' }
     let(:decide_v4_response) { JSON.parse(File.read(File.join(__dir__, 'fixtures', 'test-decide-v4.json')), symbolize_names: true) }
     describe '#get_feature_flag' do
       it 'calls the $feature_flag_called event with additional properties' do

--- a/spec/posthog/decide_spec.rb
+++ b/spec/posthog/decide_spec.rb
@@ -331,7 +331,7 @@ class PostHog
       it 'calls the $feature_flag_called event with additional properties' do
         stub_request(:post, decide_endpoint)
           .to_return(status: 200, body: decide_v4_response.to_json)
-        stub_const("PostHog::VERSION", "2.7.3")
+        stub_const("PostHog::VERSION", "2.8.0")
 
         expect(client.get_feature_flag('enabled-flag', 'test-distinct-id')).to eq(true)
 
@@ -342,7 +342,7 @@ class PostHog
           "$feature_flag_response" => true,
           "$feature_flag_request_id"=>"42853c54-1431-4861-996e-3a548989fa2c",
           "$lib"=>"posthog-ruby",
-          "$lib_version"=>"2.7.3",
+          "$lib_version"=>"2.8.0",
           "$groups"=>{},
           "locally_evaluated"=>false,
         })

--- a/spec/posthog/decide_spec.rb
+++ b/spec/posthog/decide_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+class PostHog
+  RSpec.describe 'FeatureFlagsPoller#get_decide' do
+    let(:decide_endpoint) { 'https://app.posthog.com/decide/?v=3' }
+    let(:feature_flag_endpoint) { 'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret' }
+    let(:client) { Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true) }
+    let(:poller) { client.instance_variable_get(:@feature_flags_poller) }
+    let(:decide_response) { JSON.parse(File.read(File.join(__dir__, 'fixtures', 'test-decide-v3.json')), symbolize_names: true) }
+
+    before do
+      # Stub the initial feature flag definitions request
+      stub_request(:get, feature_flag_endpoint)
+        .with(
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'Bearer testsecret',
+            'Host' => 'app.posthog.com',
+            'User-Agent' => "posthog-ruby#{PostHog::VERSION}"
+          }
+        )
+        .to_return(status: 200, body: { flags: [] }.to_json)
+    end
+
+    it 'makes a basic decide request with just distinct_id' do
+      stub_request(:post, decide_endpoint)
+        .to_return(status: 200, body: decide_response.to_json)
+
+      result = poller.get_decide("test-distinct-id")
+
+      expect(result).to eq(decide_response.merge(status: 200))
+      expect(WebMock).to have_requested(:post, decide_endpoint).with(
+        body: {
+          distinct_id: "test-distinct-id",
+          groups: {},
+          person_properties: {},
+          group_properties: {},
+          token: "testsecret"
+        }
+      )
+    end
+
+    it 'includes all parameters in the request' do
+      stub_request(:post, decide_endpoint)
+        .to_return(status: 200, body: decide_response.to_json)
+
+      result = poller.get_decide(
+        "test-distinct-id",
+        groups: { company: "test-company" },
+        person_properties: { email: "test@example.com" },
+        group_properties: { company: { name: "Test Company" } }
+      )
+
+      expect(result).to eq(decide_response.merge(status: 200))
+      expect(WebMock).to have_requested(:post, decide_endpoint).with(
+        body: {
+          distinct_id: "test-distinct-id",
+          groups: {
+            groups: { company: "test-company" },
+            person_properties: { email: "test@example.com" },
+            group_properties: { company: { name: "Test Company" } }
+          },
+          person_properties: {},
+          group_properties: {},
+          token: "testsecret"
+        }
+      )
+    end
+
+    it 'handles error responses gracefully' do
+      stub_request(:post, decide_endpoint)
+        .to_return(status: 400, body: { error: "Invalid request" }.to_json)
+
+      result = poller.get_decide("test-distinct-id")
+
+      expect(result).to eq({ error: "Invalid request", status: 400 })
+    end
+
+    it 'handles network timeouts' do
+      stub_request(:post, decide_endpoint)
+        .to_timeout
+
+      expect { poller.get_decide("test-distinct-id") }.to raise_error(Timeout::Error)
+    end
+
+    it 'handles quota limited responses' do
+      quota_limited_response = decide_response.merge(quotaLimited: ["feature_flags"])
+      stub_request(:post, decide_endpoint)
+        .to_return(status: 200, body: quota_limited_response.to_json)
+
+      result = poller.get_decide("test-distinct-id")
+
+      expect(result).to eq(quota_limited_response.merge(status: 200))
+    end
+
+    it 'handles empty responses' do
+      stub_request(:post, decide_endpoint)
+        .to_return(status: 200, body: {}.to_json)
+
+      result = poller.get_decide("test-distinct-id")
+
+      expect(result).to eq({ status: 200 })
+    end
+
+    it 'handles malformed JSON responses' do
+      stub_request(:post, decide_endpoint)
+        .to_return(status: 200, body: "invalid json")
+
+      result = poller.get_decide("test-distinct-id")
+
+      expect(result).to eq({
+        error: "Invalid JSON response",
+        body: "invalid json",
+        status: 200
+      })
+    end
+  end
+end 

--- a/spec/posthog/decide_spec.rb
+++ b/spec/posthog/decide_spec.rb
@@ -6,7 +6,7 @@ class PostHog
     let(:feature_flag_endpoint) { 'https://app.posthog.com/api/feature_flag/local_evaluation?token=testsecret' }
     let(:client) { Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true) }
     let(:poller) { client.instance_variable_get(:@feature_flags_poller) }
-    let(:decide_response) { JSON.parse(File.read(File.join(__dir__, 'fixtures', 'test-decide-v3.json')), symbolize_names: true) }
+    let(:decide_v3_response) { JSON.parse(File.read(File.join(__dir__, 'fixtures', 'test-decide-v3.json')), symbolize_names: true) }
 
     before do
       # Stub the initial feature flag definitions request
@@ -23,49 +23,84 @@ class PostHog
         .to_return(status: 200, body: { flags: [] }.to_json)
     end
 
-    it 'makes a basic decide request with just distinct_id' do
+    shared_examples 'decide response format' do |version|
+      let(:decide_response) { JSON.parse(File.read(File.join(__dir__, 'fixtures', "test-decide-#{version}.json")), symbolize_names: true) }
+
+      it 'correctly parses the response' do
+        stub_request(:post, decide_endpoint)
+          .to_return(status: 200, body: decide_response.to_json)
+
+        result = poller.get_decide("test-distinct-id")
+
+        # Verify the complete response structure
+        expect(result[:config]).to eq(enable_collect_everything: true)
+        expect(result[:featureFlags]).to include(
+          "enabled-flag": true,
+          "group-flag": true,
+          "disabled-flag": false,
+          "multi-variate-flag": "hello",
+          "simple-flag": true,
+          "beta-feature": "decide-fallback-value",
+          "beta-feature2": "variant-2"
+        )
+        expect(result[:featureFlagPayloads]).to include(
+          "enabled-flag": "{\"foo\": 1}",
+          "simple-flag": "{\"bar\": 2}",
+          "continuation-flag": "{\"foo\": \"bar\"}",
+          "beta-feature": "{\"foo\": \"bar\"}",
+          "test-get-feature": "this is a string",
+          "multi-variate-flag": "this is the payload"
+        )
+        expect(result[:status]).to eq(200)
+        expect(result[:sessionRecording]).to be false
+        expect(result[:supportedCompression]).to eq(["gzip", "gzip-js", "lz64"])
+      end
+    end
+
+    context 'with v3 response format' do
+      it_behaves_like 'decide response format', 'v3'
+    end
+
+    context 'with v4 response format' do
+      it_behaves_like 'decide response format', 'v4'
+    end
+
+    it 'transforms v3 response flags into v4 format' do
       stub_request(:post, decide_endpoint)
-        .to_return(status: 200, body: decide_response.to_json)
+        .to_return(status: 200, body: decide_v3_response.to_json)
 
       result = poller.get_decide("test-distinct-id")
 
-      expect(result).to eq(decide_response.merge(status: 200))
-      expect(WebMock).to have_requested(:post, decide_endpoint).with(
-        body: {
-          distinct_id: "test-distinct-id",
-          groups: {},
-          person_properties: {},
-          group_properties: {},
-          token: "testsecret"
-        }
-      )
-    end
+      # Verify v3 to v4 transformation
+      # We'll assert a sampling of the fields
+      expect(result[:flags]).to be_present
+      expect(result[:flags].keys).to eq([:"enabled-flag", :"group-flag", :"disabled-flag", :"multi-variate-flag", :"simple-flag", :"beta-feature", :"beta-feature2", :"false-flag-2", :"test-get-feature", :"continuation-flag"])
 
-    it 'includes all parameters in the request' do
-      stub_request(:post, decide_endpoint)
-        .to_return(status: 200, body: decide_response.to_json)
+      enabled_flag = result[:flags][:"enabled-flag"]
+      expect(enabled_flag).to be_a(FeatureFlag)
 
-      result = poller.get_decide(
-        "test-distinct-id",
-        groups: { company: "test-company" },
-        person_properties: { email: "test@example.com" },
-        group_properties: { company: { name: "Test Company" } }
-      )
+      expect(enabled_flag).to be_a(FeatureFlag)
+      expect(enabled_flag.key).to eq(:"enabled-flag")
+      expect(enabled_flag.enabled).to be true
+      expect(enabled_flag.variant).to be nil
+      expect(enabled_flag.reason).to be nil
+      expect(enabled_flag.metadata.payload).to eq("{\"foo\": 1}")
 
-      expect(result).to eq(decide_response.merge(status: 200))
-      expect(WebMock).to have_requested(:post, decide_endpoint).with(
-        body: {
-          distinct_id: "test-distinct-id",
-          groups: {
-            groups: { company: "test-company" },
-            person_properties: { email: "test@example.com" },
-            group_properties: { company: { name: "Test Company" } }
-          },
-          person_properties: {},
-          group_properties: {},
-          token: "testsecret"
-        }
-      )
+      multi_variate_flag = result[:flags][:"multi-variate-flag"]
+      expect(multi_variate_flag).to be_a(FeatureFlag)
+      expect(multi_variate_flag.key).to eq(:"multi-variate-flag")
+      expect(multi_variate_flag.enabled).to be true
+      expect(multi_variate_flag.variant).to eq("hello")
+      expect(multi_variate_flag.reason).to be nil
+      expect(multi_variate_flag.metadata.payload).to eq("this is the payload")
+
+      disabled_flag = result[:flags][:"disabled-flag"]
+      expect(disabled_flag).to be_a(FeatureFlag)
+      expect(disabled_flag.key).to eq(:"disabled-flag")
+      expect(disabled_flag.enabled).to be false
+      expect(disabled_flag.variant).to be nil
+      expect(disabled_flag.reason).to be nil
+      expect(disabled_flag.metadata.payload).to be nil
     end
 
     it 'handles error responses gracefully' do
@@ -84,8 +119,14 @@ class PostHog
       expect { poller.get_decide("test-distinct-id") }.to raise_error(Timeout::Error)
     end
 
-    it 'handles quota limited responses' do
-      quota_limited_response = decide_response.merge(quotaLimited: ["feature_flags"])
+    it 'handles quota limited responses v3' do
+      quota_limited_response = {
+        flags: {},
+        featureFlags: {},
+        featureFlagPayloads: {},
+        errorsWhileComputingFlags: true,
+        quotaLimited: ["feature_flags"]
+      }
       stub_request(:post, decide_endpoint)
         .to_return(status: 200, body: quota_limited_response.to_json)
 

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -5,7 +5,7 @@ class PostHog
 
   RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = nil
 
-  decide_endpoint = 'https://app.posthog.com/decide/?v=3'
+  decide_endpoint = 'https://app.posthog.com/decide/?v=4'
 
   describe 'local evaluation' do
   
@@ -4105,7 +4105,7 @@ class PostHog
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       # Add the exact stub for the decide endpoint as recommended in the error
-      stub_request(:post, "https://app.posthog.com/decide/?v=3").
+      stub_request(:post, "https://app.posthog.com/decide/?v=4").
         with(
           body: "{\"distinct_id\":\"distinct_id\",\"groups\":{},\"person_properties\":{\"distinct_id\":\"distinct_id\",\"region\":\"USA\"},\"group_properties\":{},\"token\":\"testsecret\"}",
           headers: {

--- a/spec/posthog/fixtures/test-decide-v3.json
+++ b/spec/posthog/fixtures/test-decide-v3.json
@@ -1,0 +1,41 @@
+{
+  "config": {
+    "enable_collect_everything": true
+  },
+  "editorParams": {},
+  "isAuthenticated": true,
+  "supportedCompression": ["gzip", "gzip-js", "lz64"],
+  "toolbarParams": {},
+  "featureFlags": {
+    "enabled-flag": true,
+    "group-flag": true,
+    "disabled-flag": false,
+    "multi-variate-flag": "hello",
+    "simple-flag": true,
+    "beta-feature": "decide-fallback-value",
+    "beta-feature2": "variant-2",
+    "false-flag-2": false,
+    "test-get-feature": "variant-1",
+    "continuation-flag": true
+  },
+  "featureFlagPayloads": {
+    "enabled-flag": "{\"foo\": 1}",
+    "simple-flag": "{\"bar\": 2}",
+    "continuation-flag": "{\"foo\": \"bar\"}",
+    "beta-feature": "{\"foo\": \"bar\"}",
+    "test-get-feature": "this is a string",
+    "multi-variate-flag": "this is the payload"
+  },
+  "sessionRecording": false,
+  "errorsWhileComputingFlags": false,
+  "capturePerformance": false,
+  "autocapture_opt_out": true,
+  "autocaptureExceptions": false,
+  "analytics": { "endpoint": "/i/v0/e/" },
+  "__preview_ingestion_endpoints": true,
+  "elementsChainAsString": true,
+  "surveys": false,
+  "heatmaps": false,
+  "siteApps": [],
+  "requestId": "42853c54-1431-4861-996e-3a548989fa2c"
+}

--- a/spec/posthog/fixtures/test-decide-v4.json
+++ b/spec/posthog/fixtures/test-decide-v4.json
@@ -1,0 +1,173 @@
+{
+  "config": {
+    "enable_collect_everything": true
+  },
+  "editorParams": {},
+  "isAuthenticated": true,
+  "supportedCompression": ["gzip", "gzip-js", "lz64"],
+  "toolbarParams": {},
+  "flags": {
+    "enabled-flag": {
+      "key": "enabled-flag",
+      "enabled": true,
+      "variant": null,
+      "reason": {
+        "code": "condition_match",
+        "description": "Matched conditions set 3",
+        "condition_index": 2
+      },
+      "metadata": {
+        "id": 1,
+        "version": 23,
+        "payload": "{\"foo\": 1}",
+        "description": "This is an enabled flag"  
+      }
+    },
+    "group-flag": {
+      "key": "group-flag",
+      "enabled": true,
+      "variant": null,
+      "reason": {
+        "code": "condition_match",
+        "description": "Matched conditions set 1",
+        "condition_index": 0
+      },
+      "metadata": {
+        "id": 2,
+        "version": 1,
+        "payload": null
+      }
+    },
+    "disabled-flag": {
+      "key": "disabled-flag",
+      "enabled": false,
+      "variant": null,
+      "reason": {
+        "code": "no_condition_match",
+        "description": "No matching condition set",
+        "condition_index": 0
+      },
+      "metadata": {
+        "id": 3,
+        "version": 12,
+        "payload": null
+      }
+    },
+    "multi-variate-flag": {
+      "key": "multi-variate-flag",
+      "enabled": true,
+      "variant": "hello",
+      "reason": {
+        "code": "condition_match",
+        "description": "Matched conditions set 2",
+        "condition_index": 1
+      },
+      "metadata": {
+        "id": 4,
+        "version": 42,
+        "payload": "this is the payload"
+      }
+    },
+    "simple-flag": {
+      "key": "simple-flag",
+      "enabled": true,
+      "variant": null,
+      "reason": {
+        "code": "condition_match",
+        "description": "Matched conditions set 1",
+        "condition_index": 0
+      },
+      "metadata": {
+        "id": 5,
+        "version": 2,
+        "payload": "{\"bar\": 2}"
+      }
+    },
+    "beta-feature": {
+      "key": "beta-feature",
+      "enabled": true,
+      "variant": "decide-fallback-value",
+      "reason": {
+        "code": "condition_match",
+        "description": "Matched conditions set 1",
+        "condition_index": 0
+      },
+      "metadata": {
+        "id": 6,
+        "version": 4,
+        "payload": "{\"foo\": \"bar\"}"
+      }
+    },
+    "beta-feature2": {
+      "key": "beta-feature2",
+      "enabled": true,
+      "variant": "variant-2",
+      "reason": {
+        "code": "condition_match",
+        "description": "Matched conditions set 3",
+        "condition_index": 2
+      },
+      "metadata": {
+        "id": 7,
+        "payload": null
+      }
+    },
+    "test-get-feature": {
+      "key": "test-get-feature",
+      "enabled": true,
+      "variant": "variant-1",
+      "reason": {
+        "code": "condition_match",
+        "description": "Matched conditions set 1",
+        "condition_index": 0
+      },
+      "metadata": {
+        "id": 8,
+        "version": 1,
+        "payload": "this is a string"
+      }
+    },
+    "continuation-flag": {
+      "key": "continuation-flag",
+      "enabled": true,
+      "variant": null,
+      "reason": {
+        "code": "condition_match",
+        "description": "Matched conditions set 1",
+        "condition_index": 0
+      },
+      "metadata": {
+        "id": 9,
+        "version": 9,
+        "payload": "{\"foo\": \"bar\"}"
+      }
+    },
+    "false-flag-2": {
+      "key": "false-flag-2",
+      "enabled": false,
+      "variant": null,
+      "reason": {
+        "code": "no_condition_match",
+        "description": "No matching condition set",
+        "condition_index": 0
+      },
+      "metadata": {
+        "id": 10,
+        "version": 1,
+        "payload": null
+      }
+    }
+  },
+  "sessionRecording": false,
+  "errorsWhileComputingFlags": false,
+  "capturePerformance": false,
+  "autocapture_opt_out": true,
+  "autocaptureExceptions": false,
+  "analytics": { "endpoint": "/i/v0/e/" },
+  "__preview_ingestion_endpoints": true,
+  "elementsChainAsString": true,
+  "surveys": false,
+  "heatmaps": false,
+  "siteApps": [],
+  "requestId": "42853c54-1431-4861-996e-3a548989fa2c"
+}


### PR DESCRIPTION
Add support for `/decide?v=4` (see https://github.com/PostHog/posthog/pull/29751). Similar to how it's done in https://github.com/PostHog/posthog-js-lite/pull/427.

## Updates to the `$feature_flag_called` event

When capturing the `$feature_flag_called` event, additional information are now captured:

The end result is `$feature_flag_called` events will have additional properties:

| Property Name                |  Descirption
| ------------------------ | -------------
| `$feature_flag_version` | The version of the feature flag. This is visible in the diffs of the feature flag activity log.
| `$feature_flag_reason` | The reason the feature flag matched or didn't match.
| `$feature_flag_id`          | The database id of the feature flag (Just in case a flag was deleted and then recreated with the same key, we can determine the difference.
| $feature_flag_request_id | The ID of the `/decide` request.

## Backwards compatibility:

The changes are all backwards compatible with `/decide?v=3`.

## Testing

Unit tests and some manual testing