### PR TITLE
chore(flags): use new `/flags` endpoint instead of `/decide`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.0 – 2025-04-30
+
+1. Use new `/flags` service to power feature flag evaluation.
+
 ## 2.8.1 – 2025-04-18
 
 1. Fix `condition_index` can be null in `/decide` requests

--- a/lib/posthog/feature_flag.rb
+++ b/lib/posthog/feature_flag.rb
@@ -1,4 +1,4 @@
-# Represents a feature flag returned by /decide v4
+# Represents a feature flag returned by /flags v2
 class FeatureFlag
   attr_reader :key, :enabled, :variant, :reason, :metadata
 

--- a/lib/posthog/version.rb
+++ b/lib/posthog/version.rb
@@ -1,3 +1,3 @@
 class PostHog
-  VERSION = '2.8.1'
+  VERSION = '2.9.0'
 end


### PR DESCRIPTION
update Ruby SDK to use the new /flags endpoint instead of the legacy /decide one.