### PR TITLE
fix: was warning on absent UUID when capturing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1 - 2025-05-20
+
+1. fix: was warning on absent UUID when capturing ([#67](https://github.com/PostHog/posthog-ruby/pull/67))
+
 ## 3.0.0 - 2025-05-20
 
 1. Drops support for Ruby 2.x ([#63](https://github.com/PostHog/posthog-ruby/pull/63)) 

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -31,7 +31,7 @@ module PostHog
 
         isoify_dates! properties
 
-        common['uuid'] = uuid if uuid? uuid
+        common['uuid'] = uuid if valid_uuid_for_event_props? uuid
 
         common.merge(
           {
@@ -174,8 +174,17 @@ module PostHog
         raise ArgumentError, "#{name} must be a Hash" unless obj.is_a? Hash
       end
 
-      def uuid?(uuid)
-        is_valid_uuid = uuid.match?(/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i) if uuid
+      # @param [Object] uuid - the UUID to validate, user provided, so we don't know the type
+      # @return [TrueClass, FalseClass] - true if the UUID is valid or absent, false otherwise
+      def valid_uuid_for_event_props?(uuid)
+        return true if uuid.nil?
+
+        unless uuid.is_a?(String)
+          logger.warn "UUID is not a string. Ignoring it."
+          return false
+        end
+
+        is_valid_uuid = uuid.match?(/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i)
         logger.warn "UUID is not valid: #{uuid}. Ignoring it." unless is_valid_uuid
 
         is_valid_uuid

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -180,7 +180,7 @@ module PostHog
         return true if uuid.nil?
 
         unless uuid.is_a?(String)
-          logger.warn "UUID is not a string. Ignoring it."
+          logger.warn 'UUID is not a string. Ignoring it.'
           return false
         end
 

--- a/lib/posthog/version.rb
+++ b/lib/posthog/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PostHog
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end


### PR DESCRIPTION
made an example app to test https://github.com/PostHog/posthog.com/pull/11535

and saw that we were logging a warning when UUID was not provided and that's silly

<img width="859" alt="Screenshot 2025-05-20 at 20 16 24" src="https://github.com/user-attachments/assets/f93c7444-80d9-4282-bcb1-4cb6db2e2562" />

don't do that