### PR TITLE
fix(flags): Pass project API key in remote_config requests

### DIFF
--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -628,7 +628,8 @@ module PostHog
     end
 
     def _request_feature_flag_definitions
-      uri = URI("#{@host}/api/feature_flag/local_evaluation?token=#{@project_api_key}")
+      uri = URI("#{@host}/api/feature_flag/local_evaluation")
+      uri.query = URI.encode_www_form([['token', @project_api_key]])
       req = Net::HTTP::Get.new(uri)
       req['Authorization'] = "Bearer #{@personal_api_key}"
 
@@ -646,7 +647,8 @@ module PostHog
     end
 
     def _request_remote_config_payload(flag_key)
-      uri = URI("#{@host}/api/projects/@current/feature_flags/#{flag_key}/remote_config/")
+      uri = URI("#{@host}/api/projects/@current/feature_flags/#{flag_key}/remote_config")
+      uri.query = URI.encode_www_form([['token', @project_api_key]])
       req = Net::HTTP::Get.new(uri)
       req['Content-Type'] = 'application/json'
       req['Authorization'] = "Bearer #{@personal_api_key}"

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -4210,7 +4210,7 @@ module PostHog
       mock_decrypted_payload = '"super secret payload in plaintext"'
       stub_request(
         :get,
-        "https://app.posthog.com/api/projects/@current/feature_flags/#{encrypted_payload_flag_key}/remote_config/"
+        "https://app.posthog.com/api/projects/@current/feature_flags/#{encrypted_payload_flag_key}/remote_config?token=testsecret"
       ).to_return(status: 200, body: mock_decrypted_payload)
       stub_request(
         :get,


### PR DESCRIPTION
Fixes the remote_config endpoint to include the project API key as a token parameter for deterministic project routing, matching the implementation in other server-side SDKs.

- Add token parameter to `remote_config` URL construction
- Add test to verify the token parameter is included in requests

See https://github.com/PostHog/posthog/issues/35303 for the problem.
Port of PostHog Python implementation: https://github.com/PostHog/posthog-python/pull/303
