### PR TITLE
Sign commits during release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,13 +91,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
           bundler-cache: true
           ruby-version: ruby
 
       - name: Configure trusted publishing credentials
-        uses: rubygems/configure-rubygems-credentials@v1.0.0
+        uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
 
       # Build and publish posthog-ruby first (posthog-rails depends on it)
       - name: Build posthog-ruby

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,14 +120,6 @@ jobs:
       - name: Wait for posthog-rails to be available
         run: gem exec rubygems-await posthog-rails/posthog-rails-*.gem
 
-      # Create and push git tag
-      - name: Create git tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ needs.check-release-label.outputs.version }}" -m "Release v${{ needs.check-release-label.outputs.version }}"
-          git push origin "v${{ needs.check-release-label.outputs.version }}"
-
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Use Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
The tag will be auto-created during the `gh release create` process, and will be automatically signed, so we don't need these manual steps.