### PR TITLE
Release 3.6.1

### DIFF
--- a/lib/posthog/version.rb
+++ b/lib/posthog/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PostHog
-  VERSION = '3.6.0'
+  VERSION = '3.6.1'
 end


### PR DESCRIPTION
Bump version to 3.6.1 to trigger release of #114 (distributed flag definition cache provider interface).