### PR TITLE
chore: add stale workflow for issues and PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,7 +5,6 @@ on:
 
 permissions:
     contents: read
-    actions: write
     issues: write
     pull-requests: write
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,44 @@
+name: 'Handle stale issues and PRs'
+on:
+    schedule:
+        - cron: '30 9 * * 1-5'
+
+permissions:
+    contents: read
+    actions: write
+    issues: write
+    pull-requests: write
+
+jobs:
+    stale:
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Check if holiday period
+              id: holiday
+              run: |
+                  # Skip during Christmas/New Year holidays (Dec 20 - Jan 3)
+                  MONTH=$(TZ=UTC date +%m)
+                  DAY=$(TZ=UTC date +%-d)
+                  if [[ "$MONTH" == "12" && $DAY -ge 20 ]] || [[ "$MONTH" == "01" && $DAY -le 3 ]]; then
+                    echo "skip=true" >> $GITHUB_OUTPUT
+                    echo "Skipping stale check during holiday period"
+                  else
+                    echo "skip=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - uses: actions/stale@v10
+              if: steps.holiday.outputs.skip != 'true'
+              with:
+                  days-before-issue-stale: 730
+                  days-before-issue-close: 14
+                  stale-issue-message: "This issue hasn't seen activity in two years! If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in two weeks."
+                  close-issue-message: "This issue was closed due to lack of activity. Feel free to reopen if it's still relevant."
+                  stale-issue-label: stale
+                  remove-issue-stale-when-updated: true
+                  days-before-pr-stale: 7
+                  days-before-pr-close: 7
+                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in another week."
+                  close-pr-message: "This PR was closed due to lack of activity. Feel free to reopen if it's still relevant."
+                  stale-pr-label: stale
+                  remove-pr-stale-when-updated: true
+                  operations-per-run: 250


### PR DESCRIPTION
## Summary

Add the stale workflow used in posthog-js so this repo automatically manages stale issues and PRs too.

## Testing

Reviewed the workflow YAML and verified it configures `actions/stale@v10` for both issues and PRs.