### PR TITLE
fix: add test_mode tracking with early return in flush

### DIFF
--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -81,6 +81,7 @@ module PostHog
       @max_queue_size = opts[:max_queue_size] || Defaults::Queue::MAX_SIZE
       @worker_mutex = Mutex.new
       @sync_mode = opts[:sync_mode] == true && !opts[:test_mode]
+      @test_mode = opts[:test_mode] == true
       @on_error = opts[:on_error] || proc { |status, error| }
       @worker = if opts[:test_mode]
                   NoopWorker.new(@queue)
@@ -142,6 +143,11 @@ module PostHog
       if @sync_mode
         # Wait for any in-flight sync send to complete
         @sync_lock.synchronize {} # rubocop:disable Lint/EmptyBlock
+        return
+      end
+
+      if @test_mode
+        @queue.clear
         return
       end
 

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1108,6 +1108,21 @@ module PostHog
           Process.wait
         end
       end
+
+      it 'clears queue immediately in test mode without hanging' do
+        test_client = PostHog::Client.new(
+          api_key: 'test-api-key',
+          test_mode: true
+        )
+        test_client.capture(distinct_id: 'test-user', event: 'test event')
+        expect(test_client.queued_messages).to eq(1)
+
+        thread = Thread.new { test_client.flush }
+        result = thread.join(2)
+
+        expect(result).not_to be_nil
+        expect(test_client.queued_messages).to eq(0)
+      end
     end
 
     describe 'feature flags' do


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog-ruby/issues/111

- track `@test_mode` as instance variable in initialize
- return early from flush when test_mode is enabled, clearing the queue
- add test to verify flush does not hang in test mode