### PR TITLE
feat(flags): switch local evaluation endpoint to /flags/definitions

### DIFF
--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -1128,7 +1128,7 @@ module PostHog
     end
 
     def _request_feature_flag_definitions(etag: nil)
-      uri = URI("#{@host}/api/feature_flag/local_evaluation")
+      uri = URI("#{@host}/flags/definitions")
       uri.query = URI.encode_www_form([['token', @project_api_key], %w[send_cohorts true]])
       req = Net::HTTP::Get.new(uri)
       req['Authorization'] = "Bearer #{@personal_api_key}"

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -278,7 +278,7 @@ module PostHog
 
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
         stub_request(:post, flags_endpoint)
           .to_return(status: 200, body: flags_response.to_json)
@@ -323,7 +323,7 @@ module PostHog
 
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
         stub_request(:post, flags_endpoint)
           .to_return(status: 200, body: flags_response.to_json)
@@ -348,7 +348,7 @@ module PostHog
                                                'off-feature' => false } }
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: {}.to_json)
         stub_request(:post, flags_endpoint)
           .to_return(status: 200, body: flags_response.to_json)
@@ -373,7 +373,7 @@ module PostHog
 
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 401, body: { 'error' => 'not authorized' }.to_json)
         stub_request(:post, flags_endpoint)
           .to_return(status: 200, body: flags_response.to_json)
@@ -390,7 +390,7 @@ module PostHog
         expect(properties['$feature/beta-feature']).to eq('random-variant')
         expect(properties['$active_feature_flags']).to eq(['beta-feature'])
 
-        assert_not_requested :get, 'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        assert_not_requested :get, 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       end
 
       it 'manages memory well when sending feature flags' do
@@ -414,7 +414,7 @@ module PostHog
         }
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
         stub_const('PostHog::Defaults::MAX_HASH_SIZE', 10)
@@ -482,7 +482,7 @@ module PostHog
 
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
         stub_const('PostHog::Defaults::MAX_HASH_SIZE', 10)
@@ -639,7 +639,7 @@ module PostHog
 
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
         stub_request(:post, flags_endpoint)
           .to_return(status: 200, body: flags_response.to_json)
@@ -677,7 +677,7 @@ module PostHog
 
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
         stub_request(:post, flags_endpoint)
           .to_return(status: 200, body: flags_response.to_json)
@@ -703,7 +703,7 @@ module PostHog
       it 'ignores feature flags with invalid send_feature_flags parameter' do
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: { flags: [] }.to_json)
         c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
 
@@ -741,7 +741,7 @@ module PostHog
         }
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
         # This should NOT be called because only_evaluate_locally is true
@@ -793,7 +793,7 @@ module PostHog
         }
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
         # This should NOT be called because only_evaluate_locally is true
@@ -844,7 +844,7 @@ module PostHog
         }
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
         # This SHOULD be called because only_evaluate_locally is explicitly false
@@ -1186,7 +1186,7 @@ module PostHog
         # Mock response for api/feature_flag
         stub_request(
           :get,
-          'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
         ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
         # Mock response for `/flags`

--- a/spec/posthog/feature_flag_error_spec.rb
+++ b/spec/posthog/feature_flag_error_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 module PostHog
   describe 'Feature Flag Error Tracking' do
     let(:flags_endpoint) { 'https://us.i.posthog.com/flags/?v=2' }
-    let(:feature_flag_endpoint) { 'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true' }
+    let(:feature_flag_endpoint) { 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true' }
     let(:client) { Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true) }
 
     before do

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -38,7 +38,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       # shouldn't call flags
@@ -89,7 +89,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       # shouldn't call flags
@@ -177,7 +177,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -252,7 +252,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -373,7 +373,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -435,7 +435,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -495,7 +495,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -554,7 +554,7 @@ module PostHog
       # We don't go to `/flags` if local eval is enabled and the flag is not in list of all flag definitions
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -573,7 +573,7 @@ module PostHog
       # TRICKY: Pretty hard to simulate a timeout using sleep with WebMock, so we'll just raise an error
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_raise(Net::ReadTimeout)
 
       stub_request(:post, flags_endpoint)
@@ -620,7 +620,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -686,7 +686,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -758,7 +758,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -780,7 +780,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -832,7 +832,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -883,7 +883,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -933,7 +933,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res_updated.to_json)
 
       # force reload to simulate poll interval
@@ -978,7 +978,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -1037,7 +1037,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -1088,7 +1088,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -1150,7 +1150,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint).to_return(status: 400)
@@ -2039,7 +2039,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       # shouldn't call `/flags`
@@ -3086,7 +3086,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       # shouldn't call `/flags`
@@ -4174,7 +4174,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => flag_res }.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -4193,7 +4193,7 @@ module PostHog
     it 'get all flags and payloads with fallback and empty local flags' do
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => [] }.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -4270,7 +4270,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => flag_res }.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -4326,7 +4326,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => [basic_flag, disabled_flag] }.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -4366,7 +4366,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => [basic_flag_res] }.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -4387,7 +4387,7 @@ module PostHog
     it 'evaluates boolean feature flags with `/flags`' do
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => [] }.to_json)
       stub_request(:post, flags_endpoint)
         .to_return(status: 200, body: { 'featureFlags' => {},
@@ -4436,7 +4436,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { flags: [multivariate_flag] }.to_json)
       stub_request(:post, flags_endpoint)
         .to_return(status: 200, body: { featureFlagPayloads: { 'first-variant' => { b: 'json' } } }.to_json)
@@ -4472,7 +4472,7 @@ module PostHog
       ).to_return(status: 200, body: mock_decrypted_payload)
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { flags: [] }.to_json)
 
       c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
@@ -4506,7 +4506,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => flag_res }.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -4556,7 +4556,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -4568,7 +4568,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 400, body: { 'error' => 'went_wrong!' }.to_json)
 
       # force reload to simulate poll interval
@@ -4609,7 +4609,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       # Add the exact stub for the `/flags` endpoint as recommended in the error
@@ -4632,7 +4632,7 @@ module PostHog
       # Now simulate quota limit with 402 response
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 402, body: { error: 'quota_limit_exceeded' }.to_json)
 
       # Force reload to simulate poll interval
@@ -4692,7 +4692,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       # Mock API response - user is in the static cohort
@@ -4749,7 +4749,7 @@ module PostHog
 
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       # Mock API response - user is in the static cohort
@@ -4792,7 +4792,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint).to_return(status: 400)
@@ -4827,7 +4827,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => [multivariate_flag] }.to_json)
 
       stub_request(:post, flags_endpoint).to_return(status: 400)
@@ -4861,7 +4861,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint).to_return(status: 400)
@@ -4895,7 +4895,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint).to_return(status: 400)
@@ -4926,7 +4926,7 @@ module PostHog
       }
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: api_feature_flag_res.to_json)
 
       stub_request(:post, flags_endpoint).to_return(status: 400)
@@ -4949,7 +4949,7 @@ module PostHog
     it 'returns nil when flag evaluation returns nil' do
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => [] }.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -4965,7 +4965,7 @@ module PostHog
     it 'falls back to remote evaluation when needed' do
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => [] }.to_json)
 
       stub_request(:post, flags_endpoint)
@@ -4994,7 +4994,7 @@ module PostHog
     it 'includes request_id and evaluated_at from remote evaluation in event' do
       stub_request(
         :get,
-        'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true'
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
       ).to_return(status: 200, body: { 'flags' => [] }.to_json)
 
       stub_request(:post, flags_endpoint)

--- a/spec/posthog/flag_definition_cache_spec.rb
+++ b/spec/posthog/flag_definition_cache_spec.rb
@@ -85,7 +85,7 @@ module PostHog
 
   describe 'flag definition cache integration' do
     let(:provider) { MockCacheProvider.new }
-    let(:local_eval_url) { 'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true' }
+    let(:local_eval_url) { 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true' }
 
     # Sample flag data with string keys (simulating JSON deserialization from cache)
     let(:sample_flags_data) do

--- a/spec/posthog/flags_spec.rb
+++ b/spec/posthog/flags_spec.rb
@@ -6,7 +6,7 @@ require 'posthog/client'
 module PostHog
   describe 'FeatureFlagsPoller#get_flags' do
     let(:flags_endpoint) { 'https://us.i.posthog.com/flags/?v=2' }
-    let(:feature_flag_endpoint) { 'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true' }
+    let(:feature_flag_endpoint) { 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true' }
     let(:client) { Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true) }
     let(:poller) { client.instance_variable_get(:@feature_flags_poller) }
     let(:flags_v3_response) do
@@ -366,7 +366,7 @@ module PostHog
 
   describe 'FeatureFlagsPoller#get_remote_config_payload' do
     let(:remote_config_endpoint) { 'https://us.i.posthog.com/api/projects/@current/feature_flags/test-flag/remote_config?token=testsecret' }
-    let(:feature_flag_endpoint) { 'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true' }
+    let(:feature_flag_endpoint) { 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true' }
     let(:client) { Client.new(api_key: 'testsecret', personal_api_key: 'personal_key', test_mode: true) }
     let(:poller) { client.instance_variable_get(:@feature_flags_poller) }
 
@@ -680,7 +680,7 @@ module PostHog
     end
 
     describe 'integration with feature flags' do
-      let(:feature_flag_endpoint) { 'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true' }
+      let(:feature_flag_endpoint) { 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true' }
       let(:client) { Client.new(api_key: 'testsecret', personal_api_key: 'personal_key', test_mode: true) }
       let(:poller) { client.instance_variable_get(:@feature_flags_poller) }
 
@@ -782,7 +782,7 @@ module PostHog
 
   describe 'Flag dependencies' do
     let(:flags_endpoint) { 'https://us.i.posthog.com/flags/?v=2' }
-    let(:feature_flag_endpoint) { 'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true' }
+    let(:feature_flag_endpoint) { 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true' }
     let(:client) { Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true) }
     let(:poller) { client.instance_variable_get(:@feature_flags_poller) }
 
@@ -1529,7 +1529,7 @@ module PostHog
 
     before do
       # Stub the initial feature flag definitions request
-      stub_request(:get, 'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true')
+      stub_request(:get, 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true')
         .to_return(status: 200, body: { flags: [] }.to_json)
     end
 
@@ -1621,7 +1621,7 @@ module PostHog
   end
 
   describe 'FeatureFlagsPoller ETag support' do
-    let(:feature_flag_endpoint) { 'https://us.i.posthog.com/api/feature_flag/local_evaluation?token=testsecret&send_cohorts=true' }
+    let(:feature_flag_endpoint) { 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true' }
     let(:client) { Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true) }
     let(:poller) { client.instance_variable_get(:@feature_flags_poller) }
 


### PR DESCRIPTION
## Motivation and Context

The Rust feature flags definitions fleet now serves 100% of `/api/feature_flag/local_evaluation` traffic in all environments. This switches the SDK's default polling URL from the legacy Django path to the Rust endpoint's native path (`/flags/definitions`).

The old `/api/feature_flag/local_evaluation` path remains registered as a route alias on the Rust service, so older SDK versions continue to work.

## How did you test it?

- Updated all WebMock stub URLs across 5 spec files
- The `/flags/definitions` endpoint has been serving production traffic since 2026-04-09