### PR TITLE
chore: use engineering@posthog.com in package metadata

### DIFF
--- a/posthog-rails/posthog-rails.gemspec
+++ b/posthog-rails/posthog-rails.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary = 'PostHog integration for Rails'
   spec.description = 'Automatic exception tracking and instrumentation for Ruby on Rails applications using PostHog'
   spec.authors = ['PostHog']
-  spec.email = 'hey@posthog.com'
+  spec.email = 'engineering@posthog.com'
   spec.homepage = 'https://github.com/PostHog/posthog-ruby'
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.0'

--- a/posthog-ruby.gemspec
+++ b/posthog-ruby.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary = 'PostHog library'
   spec.description = 'The PostHog ruby library'
   spec.authors = ['']
-  spec.email = 'hey@posthog.com'
+  spec.email = 'engineering@posthog.com'
   spec.homepage = 'https://github.com/PostHog/posthog-ruby'
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.0'


### PR DESCRIPTION
## Problem

RubyGems metadata still uses `hey@posthog.com` as the package contact email. We want package metadata to consistently use `engineering@posthog.com`.

## Changes

- Updated `posthog-ruby.gemspec` and `posthog-rails/posthog-rails.gemspec`
- Replaced `hey@posthog.com` with `engineering@posthog.com`

## How did you test it?

- Verified both gemspecs now use `engineering@posthog.com`
- Confirmed there are no other non-`engineering@posthog.com` `@posthog.com` addresses in package metadata files in this repo
