### PR TITLE
docs: move release guide to RELEASING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,24 +36,4 @@ Specifically, the [Ruby integration](https://posthog.com/docs/integrations/ruby-
 1. Run `bin/test` (this ends up calling `bundle exec rspec`)
 2. An example of running specific tests: `bin/test spec/posthog/client_spec.rb:26`
 
-## How to release
-
-Both `posthog-ruby` and `posthog-rails` are released together with the same version number.
-
-1. Create a PR that:
-   - Updates `lib/posthog/version.rb` with the new version
-   - Updates `CHANGELOG.md` with the changes and current date
-
-2. Add the `release` label to the PR
-
-3. Merge the PR to `main`
-
-4. The release workflow will:
-   - Notify the Client Libraries team in Slack
-   - Wait for approval via the GitHub `Release` environment
-   - Publish both gems to RubyGems (via trusted publishing)
-   - Create and push a git tag
-
-5. Approve the release in GitHub when prompted
-
-The workflow handles publishing both `posthog-ruby` and `posthog-rails` in the correct order (since `posthog-rails` depends on `posthog-ruby`).
+For release instructions, see [RELEASING.md](RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,21 @@
+# Releasing
+
+Both `posthog-ruby` and `posthog-rails` are released together with the same version number.
+
+1. Create a PR that:
+   - Updates `lib/posthog/version.rb` with the new version
+   - Updates `CHANGELOG.md` with the changes and current date
+
+2. Add the `release` label to the PR
+
+3. Merge the PR to `main`
+
+4. The release workflow will:
+   - Notify the Client Libraries team in Slack
+   - Wait for approval via the GitHub `Release` environment
+   - Publish both gems to RubyGems (via trusted publishing)
+   - Create and push a git tag
+
+5. Approve the release in GitHub when prompted
+
+The workflow handles publishing both `posthog-ruby` and `posthog-rails` in the correct order (since `posthog-rails` depends on `posthog-ruby`).


### PR DESCRIPTION
## Problem

The release instructions currently live in `README.md`, so the repo does not have a dedicated release guide like the other SDK repos.

## Changes

- added `RELEASING.md` with the existing Ruby release flow
- removed the detailed release section from `README.md`
- left a short pointer in `README.md` to keep `RELEASING.md` as the source of truth

## Checklist

- [ ] Tests for new code (if applicable)
- [x] Updated the docs
- [x] No breaking change
