### PR TITLE
chore: fix pnpm setup order in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,16 +98,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: 10.33.0
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
-        with:
-          version: 10.33.0
 
       - name: Install changesets dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## :bulb: Motivation and Context

The new release workflow fails before dependency installation because `actions/setup-node` tries to enable pnpm caching before the `pnpm` executable is available on `PATH`.

## :green_heart: How did you test it?

- Re-read the release workflow and verified `pnpm/action-setup` now runs before `actions/setup-node`
- Parsed `.github/workflows/release.yml` with Ruby YAML to confirm the workflow file is still valid

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
