### PR TITLE
chore: simplify ruby release token usage

### DIFF
--- a/.changeset/fuzzy-stars-wave.md
+++ b/.changeset/fuzzy-stars-wave.md
@@ -1,0 +1,5 @@
+---
+'posthog-ruby': patch
+---
+
+Simplify Ruby release token usage to retry the automated release flow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,14 @@ jobs:
           NEW_VERSION: ${{ steps.apply-changesets.outputs.new-version }}
         run: ./scripts/bump-version.sh "$NEW_VERSION"
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
+        with:
+          ruby-version: ruby
+
+      - name: Update Gemfile.lock
+        run: bundle lock
+
       - name: Commit version bump
         id: commit-version-bump
         uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,19 +193,11 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - name: Get GitHub App token
-        id: releaser
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.GH_APP_POSTHOG_RUBY_RELEASER_APP_ID }}
-          private-key: ${{ secrets.GH_APP_POSTHOG_RUBY_RELEASER_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ steps.releaser.outputs.token }}
 
       - name: Configure Git
         run: |
@@ -242,17 +234,15 @@ jobs:
 
       - name: Tag repository
         env:
-          GH_TOKEN: ${{ steps.releaser.outputs.token }}
           NEW_VERSION: ${{ needs.version-bump.outputs.new-version }}
           COMMIT_HASH: ${{ needs.version-bump.outputs.commit-hash }}
         run: |
-          gh api "repos/${{ github.repository }}/git/refs" \
-            -f "ref=refs/tags/${NEW_VERSION}" \
-            -f "sha=${COMMIT_HASH}"
+          git tag -a "$NEW_VERSION" "$COMMIT_HASH" -m "$NEW_VERSION"
+          git push origin "$NEW_VERSION"
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ steps.releaser.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           NEW_VERSION: ${{ needs.version-bump.outputs.new-version }}
         run: |
           gh release create "$NEW_VERSION" \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    posthog-ruby (3.6.1)
+    posthog-ruby (3.6.2)
       concurrent-ruby (~> 1)
 
 GEM
@@ -286,7 +286,7 @@ CHECKSUMS
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
-  posthog-ruby (3.6.1)
+  posthog-ruby (3.6.2)
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettier (4.0.4) sha256=713110c77675de802806b4e09b4b7783e497689db3e8a991f812aa78f4835bc5
   prettier_print (1.2.1) sha256=a72838b5f23facff21f90a5423cdcdda19e4271092b41f4ea7f50b83929e6ff9


### PR DESCRIPTION
## :bulb: Motivation and Context

The Ruby release workflow was requesting a GitHub App token twice, once in `version-bump` and again in `publish`. Other SDK repos like `posthog-react-native-session-replay` only need the app token in the version-bump job, so the duplicate setup adds unnecessary complexity and another failure point.

This PR also fixes the next release failure mode: once the version bump updates `lib/posthog/version.rb`, Bundler sees the path gem version change and requires `Gemfile.lock` to be refreshed before the publish job can run with frozen lockfile settings.

This PR includes a patch changeset so merging it can exercise the release automation again.

## :green_heart: How did you test it?

- compared the Ruby workflow with `posthog-react-native-session-replay/.github/workflows/release.yml`
- updated `publish` to use the default checkout/token flow and kept the GitHub App token only in `version-bump`
- parsed `.github/workflows/release.yml` with Ruby YAML to confirm the workflow file is still valid
- added a patch changeset and verified `pnpm changeset status` computes the next release as `3.6.3`
- locally changed the gem version and verified `bundle lock` updates `Gemfile.lock` to match, which addresses the frozen lockfile failure in publish

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
