### PR TITLE
chore: retry ruby release flow

### DIFF
--- a/.changeset/bright-candles-spark.md
+++ b/.changeset/bright-candles-spark.md
@@ -1,0 +1,5 @@
+---
+'posthog-ruby': patch
+---
+
+Trigger another patch release to verify the Ruby release workflow.


### PR DESCRIPTION
## :bulb: Motivation and Context

This PR adds a patch changeset so we can exercise the Ruby SDK release workflow again after the recent release automation fixes.

## :green_heart: How did you test it?

- Ran `pnpm changeset status` to verify the repo recognizes the new changeset
- Confirmed the next computed release version is `3.6.4`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
