### PR TITLE
docs: add contributing guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for your interest in improving the PostHog Ruby SDK.
+
+## Developing locally
+
+1. Install `asdf` to manage your Ruby version: `brew install asdf`
+2. Install Ruby's plugin: `asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git`
+3. Install the required Ruby version: `asdf install`
+4. Install dependencies: `bundle install`
+
+## Running the example file
+
+1. Build the gem:
+
+   ```bash
+   gem build posthog-ruby.gemspec
+   ```
+
+2. Install it locally:
+
+   ```bash
+   gem install ./posthog-ruby-<version>.gem
+   ```
+
+3. Run the example:
+
+   ```bash
+   ruby example.rb
+   ```
+
+## Testing
+
+1. Run the full test suite:
+
+   ```bash
+   bin/test
+   ```
+
+2. Run a specific test if needed:
+
+   ```bash
+   bin/test spec/posthog/client_spec.rb:26
+   ```
+
+## Rails package
+
+The `posthog-rails` package has its own package-specific guide in [posthog-rails/CONTRIBUTING.md](posthog-rails/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -18,22 +18,8 @@ Specifically, the [Ruby integration](https://posthog.com/docs/integrations/ruby-
 
 **Using Rails?** Check out [posthog-rails](posthog-rails/README.md) for automatic exception tracking, ActiveJob instrumentation, and Rails-specific features.
 
-## Developing Locally
+## Contributing
 
-1. Install `asdf` to manage your Ruby version: `brew install asdf`
-1. Install Ruby's plugin via `asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git`
-1. Make `asdf` install the required version by running `asdf install`
-1. Run `bundle install` to install dependencies
-
-## Running example file
-
-1. Build the `posthog-ruby` gem by calling: `gem build posthog-ruby.gemspec`.
-2. Install the gem locally: `gem install ./posthog-ruby-<version>.gem`
-3. Run `ruby example.rb`
-
-## Testing
-
-1. Run `bin/test` (this ends up calling `bundle exec rspec`)
-2. An example of running specific tests: `bin/test spec/posthog/client_spec.rb:26`
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, example, and test instructions.
 
 For release instructions, see [RELEASING.md](RELEASING.md).

--- a/posthog-rails/CONTRIBUTING.md
+++ b/posthog-rails/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+This guide covers package-specific development for `posthog-rails`.
+
+For repository-level setup, see the root [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Development
+
+Run the package tests from the repository root:
+
+```bash
+bundle install
+bundle exec rspec
+```
+
+## Pull requests
+
+Please keep changes focused, update tests when behavior changes, and follow the existing package conventions.

--- a/posthog-rails/README.md
+++ b/posthog-rails/README.md
@@ -393,15 +393,9 @@ RSpec.configure do |config|
 end
 ```
 
-## Development
+## Contributing
 
-To run tests:
-
-```bash
-cd posthog-rails
-bundle install
-bundle exec rspec
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for package-specific development instructions.
 
 ## Architecture
 
@@ -445,10 +439,6 @@ Ensure you've set `personal_api_key`:
 ```ruby
 config.personal_api_key = ENV['POSTHOG_PERSONAL_API_KEY']
 ```
-
-## Contributing
-
-See the main [PostHog Ruby](../README.md) repository for contribution guidelines.
 
 ## License
 


### PR DESCRIPTION
## :bulb: Motivation and Context

The repo-level and `posthog-rails` package development instructions were split across README files.

This PR moves that contributor guidance into dedicated `CONTRIBUTING.md` files so both the root package and `posthog-rails` follow the same convention.

## :green_heart: How did you test it?

- Not run (docs-only changes)
- Checked the updated markdown links and file locations

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR
