### PR TITLE
docs: align contributing guides with CI checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,19 +29,14 @@ Thanks for your interest in improving the PostHog Ruby SDK.
    ruby example.rb
    ```
 
-## Testing
+## CI-aligned checks
 
-1. Run the full test suite:
+Run the same checks CI uses before opening a PR:
 
-   ```bash
-   bin/test
-   ```
-
-2. Run a specific test if needed:
-
-   ```bash
-   bin/test spec/posthog/client_spec.rb:26
-   ```
+```bash
+bundle exec rspec
+bundle exec rubocop
+```
 
 ## Rails package
 

--- a/posthog-rails/CONTRIBUTING.md
+++ b/posthog-rails/CONTRIBUTING.md
@@ -4,13 +4,13 @@ This guide covers package-specific development for `posthog-rails`.
 
 For repository-level setup, see the root [CONTRIBUTING.md](../CONTRIBUTING.md).
 
-## Development
+## CI-aligned checks
 
-Run the package tests from the repository root:
+Run the same checks CI uses before opening a PR:
 
 ```bash
-bundle install
 bundle exec rspec
+bundle exec rubocop
 ```
 
 ## Pull requests


### PR DESCRIPTION
## :bulb: Motivation and Context

The repo-level and `posthog-rails` contributing guides did not mention all of the checks we currently run in CI.

This PR updates both guides so contributors are told to run the same RSpec and RuboCop commands we use in GitHub Actions.

## :green_heart: How did you test it?

- Not run (docs-only changes)
- Compared the updated commands against `.github/workflows/unit-tests.yml`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR
