### PR TITLE
chore: trigger releases from main changesets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,5 @@
 ### If releasing new changes
 
 - [ ] Ran `pnpm changeset` to generate a changeset file
-- [ ] Added the `release` label to the PR
 
 <!-- For more details check RELEASING.md -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - '.changeset/**'
+      - '.changeset/*.md'
   workflow_dispatch:
 
 permissions:
@@ -133,7 +133,7 @@ jobs:
         id: commit-version-bump
         uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
         with:
-          commit_message: "chore: release ${{ steps.apply-changesets.outputs.new-version }} [version bump]"
+          commit_message: "chore: release ${{ steps.apply-changesets.outputs.new-version }} [version bump] [skip ci]"
           repo: ${{ github.repository }}
           branch: main
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,17 @@
 name: "Release"
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
+    paths:
+      - '.changeset/**'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 # Concurrency control: only one release process can run at a time
-# This prevents race conditions if multiple PRs with 'release' label merge simultaneously
+# This prevents race conditions if multiple releasable changesets merge simultaneously
 concurrency:
   group: release
   cancel-in-progress: false
@@ -19,11 +20,6 @@ jobs:
   check-changesets:
     name: Check for changesets
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'release'))
     outputs:
       has-changesets: ${{ steps.check.outputs.has-changesets }}
     steps:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ This prompts you to select the version bump (`patch`, `minor`, or `major`) and w
 
 After review, merge the PR to `main`. No GitHub release label is required.
 
-A push to `main` that includes `.changeset/**` changes automatically starts the release workflow. The workflow then:
+A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
 
 1. Checks for pending changesets
 2. Notifies the client libraries team in Slack for approval

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,45 +1,46 @@
 # Releasing
 
-This repository uses [Changesets](https://github.com/changesets/changesets) for version management and an automated GitHub Actions workflow for releases.
+This repository uses [Changesets](https://github.com/changesets/changesets) for version management and changelog generation, with GitHub Actions publishing both `posthog-ruby` and `posthog-rails` to RubyGems.
 
-## How to Release
+Both gems are released together with the same version number.
 
-### 1. Add a Changeset
+## How to release
 
-When making a change that should be released, add a changeset:
+### 1. Add a changeset
+
+When making changes that should be released, add a changeset:
 
 ```bash
 pnpm changeset
 ```
 
-This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
+This will prompt you to:
+- select the release type (`patch`, `minor`, or `major`)
+- write a summary of the change
 
-### 2. Merge the Pull Request
+The changeset file will be created in the `.changeset/` directory.
 
-After review, merge the PR to `main`. No GitHub release label is required.
+### 2. Create a pull request
 
-A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
+Create a PR with your code changes and the changeset file.
 
-1. Checks for pending changesets
-2. Notifies the client libraries team in Slack for approval
-3. Waits for approval from a maintainer via the GitHub `Release` environment
-4. The workflow applies Changesets, syncs gem versions, publishes the gems, tags the release, and creates a GitHub Release.
-5. Notifies Slack when the release completes or fails
+### 3. Merge the PR
 
-### Manual Trigger
+No release label is required. When the PR is merged to `main`, the release workflow will automatically:
 
-You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
+1. Check for pending changesets
+2. Notify the Client Libraries team in Slack for approval
+3. Wait for approval via the GitHub `Release` environment
+4. Once approved:
+   - Apply changesets and bump `package.json`
+   - Update `CHANGELOG.md`
+   - Sync the version to `lib/posthog/version.rb`
+   - Commit the version bump to `main`
+   - Publish `posthog-ruby` and `posthog-rails` to RubyGems
+   - Create a git tag and GitHub release
 
-## Version Bumping
+The workflow publishes `posthog-ruby` first, then `posthog-rails`, since `posthog-rails` depends on `posthog-ruby`.
 
-Changesets determines the next version from the committed changeset files:
+## Manual trigger
 
-- **patch**: bug fixes, documentation updates, and internal changes
-- **minor**: backwards-compatible features
-- **major**: breaking changes
-
-## Troubleshooting
-
-### No changesets found
-
-If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.
+You can also manually trigger the release workflow from the Actions tab, as long as there are pending changesets.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,50 +1,45 @@
 # Releasing
 
-This repository uses [Changesets](https://github.com/changesets/changesets) for version management and changelog generation, with GitHub Actions publishing both `posthog-ruby` and `posthog-rails` to RubyGems.
+This repository uses [Changesets](https://github.com/changesets/changesets) for version management and an automated GitHub Actions workflow for releases.
 
-Both gems are released together with the same version number.
+## How to Release
 
-## How to release
+### 1. Add a Changeset
 
-### 1. Add a changeset
-
-When making changes that should be released, add a changeset:
+When making a change that should be released, add a changeset:
 
 ```bash
 pnpm changeset
 ```
 
-This will prompt you to:
-- select the release type (`patch`, `minor`, or `major`)
-- write a summary of the change
+This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
 
-The changeset file will be created in the `.changeset/` directory.
+### 2. Merge the Pull Request
 
-### 2. Create a pull request
+After review, merge the PR to `main`. No GitHub release label is required.
 
-Create a PR with your code changes and the changeset file.
+A push to `main` that includes `.changeset/**` changes automatically starts the release workflow. The workflow then:
 
-### 3. Add the `release` label
+1. Checks for pending changesets
+2. Notifies the client libraries team in Slack for approval
+3. Waits for approval from a maintainer via the GitHub `Release` environment
+4. The workflow applies Changesets, syncs gem versions, publishes the gems, tags the release, and creates a GitHub Release.
+5. Notifies Slack when the release completes or fails
 
-When the PR is ready to be released, add the `release` label.
+### Manual Trigger
 
-### 4. Merge the PR
+You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
 
-When a PR with the `release` label is merged to `main`, the release workflow will automatically:
+## Version Bumping
 
-1. Check for pending changesets
-2. Notify the Client Libraries team in Slack for approval
-3. Wait for approval via the GitHub `Release` environment
-4. Once approved:
-   - Apply changesets and bump `package.json`
-   - Update `CHANGELOG.md`
-   - Sync the version to `lib/posthog/version.rb`
-   - Commit the version bump to `main`
-   - Publish `posthog-ruby` and `posthog-rails` to RubyGems
-   - Create a git tag and GitHub release
+Changesets determines the next version from the committed changeset files:
 
-The workflow publishes `posthog-ruby` first, then `posthog-rails`, since `posthog-rails` depends on `posthog-ruby`.
+- **patch**: bug fixes, documentation updates, and internal changes
+- **minor**: backwards-compatible features
+- **major**: breaking changes
 
-## Manual trigger
+## Troubleshooting
 
-You can also manually trigger the release workflow from the Actions tab, as long as there are pending changesets.
+### No changesets found
+
+If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.


### PR DESCRIPTION
## :bulb: Motivation and Context
Standardize SDK releases so they are triggered by pushes to `main` containing release changesets, rather than by PR labels or `pull_request.closed` events.

## Changes
- Updated the release workflow to run on `push` to `main` for `.changeset/**`, while keeping manual `workflow_dispatch`
- Removed release-label and bump-label checks from the release flow
- Added `[skip ci]` to release version-bump commits and narrowed release path filters to changeset markdown files to avoid re-triggering release workflows on consumed changeset deletions
- Updated only the release-label parts of the release docs and PR checklist

## :green_heart: How did you test it?
- Parsed the updated release workflow YAML locally
- Verified the release workflow no longer references `pull_request`, PR labels, or bump labels
- Verified PR templates no longer ask for release labels

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not needed for this release-process-only change)