### PR TITLE
Run Ruby unit tests on main pushes

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,10 @@
 name: Unit Tests
 
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
## :bulb: Motivation and Context
Ensure the Ruby SDK's unit test workflow also runs after changes land on `main`, so regressions introduced by merges are caught on the default branch.

## :green_heart: How did you test it?
Validated the workflow YAML parses and now includes `push` for the `main` branch.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
