### PR TITLE
chore: use changelog for GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,9 +249,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           NEW_VERSION: ${{ needs.version-bump.outputs.new-version }}
         run: |
+          CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1; next} flag; END{if (!flag) print defText}' CHANGELOG.md | sed '/[^[:space:]]/,$!d' | tac | sed '/[^[:space:]]/,$!d' | tac)
           gh release create "$NEW_VERSION" \
             --title "$NEW_VERSION" \
-            --generate-notes
+            --notes "$CHANGELOG_ENTRY"
 
       - name: Send failure event to PostHog
         if: ${{ failure() }}


### PR DESCRIPTION
## :bulb: Motivation and Context
GitHub releases should use the SDK changelog entry as the release body instead of auto-generated release notes, so published release notes match the changelog markdown.



## :green_heart: How did you test it?
- Ran `git diff --check`.
- Reviewed the release workflow diff against other SDK release workflows that read `CHANGELOG.md` before creating GitHub releases.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
