### PR TITLE
fix: include group context in $feature_flag_called dedupe key

### DIFF
--- a/.changeset/include-group-context-in-flag-called-dedupe.md
+++ b/.changeset/include-group-context-in-flag-called-dedupe.md
@@ -1,0 +1,5 @@
+---
+'posthog-ruby': patch
+---
+
+Include group context in the `$feature_flag_called` dedupe key so group-scoped flags fire a separate event for each group a user is evaluated under, instead of being dedup-ed against the first group context the same `(distinct_id, flag, response)` was seen under.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'time'
+require 'json'
 require 'securerandom'
 
 require 'posthog/defaults'
@@ -760,11 +761,22 @@ module PostHog
     # Shared by the legacy single-flag path ({#get_feature_flag_result}) and the
     # snapshot's access-recording. Owns dedup-key construction, the
     # per-distinct_id sent-flags cache, and the `$feature_flag_called` capture call.
+    # Group context is included in the dedup key so group-scoped flags fire a
+    # separate event for each group a user is evaluated under.
     def _capture_feature_flag_called_if_needed(
       distinct_id: nil, key: nil, response: nil, properties: nil,
       groups: nil, disable_geoip: nil
     )
-      reported_key = "#{key}_#{response.nil? ? '::null::' : response}"
+      response_repr = response.nil? ? '::null::' : response
+      groups_repr =
+        if groups && !groups.empty?
+          # Canonicalize so two equal hashes with keys inserted in a different
+          # order produce the same dedup key.
+          "_#{groups.sort.to_json}"
+        else
+          ''
+        end
+      reported_key = "#{key}_#{response_repr}#{groups_repr}"
       return if @distinct_id_has_sent_flag_calls[distinct_id].include?(reported_key)
 
       msg = {

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -575,6 +575,112 @@ module PostHog
                )).to eq(true)
       end
 
+      it '$feature_flag_called fires per group context (group-scoped dedup)' do
+        api_feature_flag_res = {
+          'flags' => [
+            {
+              'id' => 1,
+              'name' => 'Group flag',
+              'key' => 'group-flag',
+              'active' => true,
+              'filters' => {
+                'groups' => [
+                  { 'properties' => [], 'rollout_percentage' => 100 }
+                ]
+              }
+            }
+          ]
+        }
+
+        stub_request(
+          :get,
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
+        ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+        c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+        allow(c).to receive(:capture)
+
+        # Same user, same flag, same response — but two different group contexts.
+        expect(c).to receive(:capture).with(hash_including(
+                                              distinct_id: 'user-1',
+                                              event: '$feature_flag_called',
+                                              groups: { organization: 'org-a' }
+                                            )).exactly(1).times
+        expect(c).to receive(:capture).with(hash_including(
+                                              distinct_id: 'user-1',
+                                              event: '$feature_flag_called',
+                                              groups: { organization: 'org-b' }
+                                            )).exactly(1).times
+
+        c.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-a' })
+        c.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-b' })
+      end
+
+      it '$feature_flag_called dedupes across repeated calls under the same group context' do
+        api_feature_flag_res = {
+          'flags' => [
+            {
+              'id' => 1,
+              'name' => 'Group flag',
+              'key' => 'group-flag',
+              'active' => true,
+              'filters' => {
+                'groups' => [
+                  { 'properties' => [], 'rollout_percentage' => 100 }
+                ]
+              }
+            }
+          ]
+        }
+
+        stub_request(
+          :get,
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
+        ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+        c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+        allow(c).to receive(:capture)
+
+        expect(c).to receive(:capture).with(hash_including(
+                                              event: '$feature_flag_called',
+                                              groups: { organization: 'org-a' }
+                                            )).exactly(1).times
+
+        c.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-a' })
+        c.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-a' })
+      end
+
+      it '$feature_flag_called dedupes when same groups are passed in different key order' do
+        api_feature_flag_res = {
+          'flags' => [
+            {
+              'id' => 1,
+              'name' => 'Group flag',
+              'key' => 'group-flag',
+              'active' => true,
+              'filters' => {
+                'groups' => [
+                  { 'properties' => [], 'rollout_percentage' => 100 }
+                ]
+              }
+            }
+          ]
+        }
+
+        stub_request(
+          :get,
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
+        ).to_return(status: 200, body: api_feature_flag_res.to_json)
+
+        c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+        allow(c).to receive(:capture)
+
+        expect(c).to receive(:capture).with(hash_including(event: '$feature_flag_called')).exactly(1).times
+
+        c.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-a', team: 'red' })
+        c.get_feature_flag('group-flag', 'user-1', groups: { team: 'red', organization: 'org-a' })
+      end
+
       it 'captures groups' do
         client.capture(
           {

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -622,10 +622,13 @@ module PostHog
 
         [
           ['repeated calls with the same context', { organization: 'org-a' }, { organization: 'org-a' }],
-          ['same groups in different key order', { organization: 'org-a', team: 'red' }, { team: 'red', organization: 'org-a' }]
+          ['same groups in different key order',
+           { organization: 'org-a', team: 'red' },
+           { team: 'red', organization: 'org-a' }]
         ].each do |description, first_groups, second_groups|
           it "dedupes on #{description}" do
-            expect(group_flag_client).to receive(:capture).with(hash_including(event: '$feature_flag_called')).exactly(1).times
+            expect(group_flag_client)
+              .to receive(:capture).with(hash_including(event: '$feature_flag_called')).exactly(1).times
 
             group_flag_client.get_feature_flag('group-flag', 'user-1', groups: first_groups)
             group_flag_client.get_feature_flag('group-flag', 'user-1', groups: second_groups)

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -575,110 +575,62 @@ module PostHog
                )).to eq(true)
       end
 
-      it '$feature_flag_called fires per group context (group-scoped dedup)' do
-        api_feature_flag_res = {
-          'flags' => [
-            {
-              'id' => 1,
-              'name' => 'Group flag',
-              'key' => 'group-flag',
-              'active' => true,
-              'filters' => {
-                'groups' => [
-                  { 'properties' => [], 'rollout_percentage' => 100 }
-                ]
+      context '$feature_flag_called group-context deduplication' do
+        let(:group_flag_api_res) do
+          {
+            'flags' => [
+              {
+                'id' => 1,
+                'name' => 'Group flag',
+                'key' => 'group-flag',
+                'active' => true,
+                'filters' => {
+                  'groups' => [
+                    { 'properties' => [], 'rollout_percentage' => 100 }
+                  ]
+                }
               }
-            }
-          ]
-        }
+            ]
+          }
+        end
 
-        stub_request(
-          :get,
-          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
-        ).to_return(status: 200, body: api_feature_flag_res.to_json)
+        let(:group_flag_client) do
+          stub_request(
+            :get,
+            'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
+          ).to_return(status: 200, body: group_flag_api_res.to_json)
+          c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+          allow(c).to receive(:capture)
+          c
+        end
 
-        c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
-        allow(c).to receive(:capture)
+        it 'fires once per distinct group context' do
+          expect(group_flag_client).to receive(:capture).with(hash_including(
+                                                                distinct_id: 'user-1',
+                                                                event: '$feature_flag_called',
+                                                                groups: { organization: 'org-a' }
+                                                              )).exactly(1).times
+          expect(group_flag_client).to receive(:capture).with(hash_including(
+                                                                distinct_id: 'user-1',
+                                                                event: '$feature_flag_called',
+                                                                groups: { organization: 'org-b' }
+                                                              )).exactly(1).times
 
-        # Same user, same flag, same response — but two different group contexts.
-        expect(c).to receive(:capture).with(hash_including(
-                                              distinct_id: 'user-1',
-                                              event: '$feature_flag_called',
-                                              groups: { organization: 'org-a' }
-                                            )).exactly(1).times
-        expect(c).to receive(:capture).with(hash_including(
-                                              distinct_id: 'user-1',
-                                              event: '$feature_flag_called',
-                                              groups: { organization: 'org-b' }
-                                            )).exactly(1).times
+          group_flag_client.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-a' })
+          group_flag_client.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-b' })
+        end
 
-        c.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-a' })
-        c.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-b' })
-      end
+        [
+          ['repeated calls with the same context', { organization: 'org-a' }, { organization: 'org-a' }],
+          ['same groups in different key order', { organization: 'org-a', team: 'red' }, { team: 'red', organization: 'org-a' }]
+        ].each do |description, first_groups, second_groups|
+          it "dedupes on #{description}" do
+            expect(group_flag_client).to receive(:capture).with(hash_including(event: '$feature_flag_called')).exactly(1).times
 
-      it '$feature_flag_called dedupes across repeated calls under the same group context' do
-        api_feature_flag_res = {
-          'flags' => [
-            {
-              'id' => 1,
-              'name' => 'Group flag',
-              'key' => 'group-flag',
-              'active' => true,
-              'filters' => {
-                'groups' => [
-                  { 'properties' => [], 'rollout_percentage' => 100 }
-                ]
-              }
-            }
-          ]
-        }
-
-        stub_request(
-          :get,
-          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
-        ).to_return(status: 200, body: api_feature_flag_res.to_json)
-
-        c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
-        allow(c).to receive(:capture)
-
-        expect(c).to receive(:capture).with(hash_including(
-                                              event: '$feature_flag_called',
-                                              groups: { organization: 'org-a' }
-                                            )).exactly(1).times
-
-        c.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-a' })
-        c.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-a' })
-      end
-
-      it '$feature_flag_called dedupes when same groups are passed in different key order' do
-        api_feature_flag_res = {
-          'flags' => [
-            {
-              'id' => 1,
-              'name' => 'Group flag',
-              'key' => 'group-flag',
-              'active' => true,
-              'filters' => {
-                'groups' => [
-                  { 'properties' => [], 'rollout_percentage' => 100 }
-                ]
-              }
-            }
-          ]
-        }
-
-        stub_request(
-          :get,
-          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
-        ).to_return(status: 200, body: api_feature_flag_res.to_json)
-
-        c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
-        allow(c).to receive(:capture)
-
-        expect(c).to receive(:capture).with(hash_including(event: '$feature_flag_called')).exactly(1).times
-
-        c.get_feature_flag('group-flag', 'user-1', groups: { organization: 'org-a', team: 'red' })
-        c.get_feature_flag('group-flag', 'user-1', groups: { team: 'red', organization: 'org-a' })
+            group_flag_client.get_feature_flag('group-flag', 'user-1', groups: first_groups)
+            group_flag_client.get_feature_flag('group-flag', 'user-1', groups: second_groups)
+          end
+        end
       end
 
       it 'captures groups' do


### PR DESCRIPTION
## :bulb: Motivation and Context

In `_capture_feature_flag_called_if_needed` (`lib/posthog/client.rb`), the per-`distinct_id` dedupe key only included the flag key and response. For group-scoped flags this meant that when the same user was evaluated under a different group, no new `$feature_flag_called` event was fired — causing per-group exposure undercount for experiments scoped to a group key.

Mirrors the posthog-node fix in PostHog/posthog-js#3658 (which closes PostHog/posthog-js#3651). Both SDKs share the same dedupe shape, so backend evaluation needs the same change.

## :green_heart: How did you test it?

Added three rspec examples covering the new behavior in `spec/posthog/client_spec.rb`:

- `$feature_flag_called fires per group context (group-scoped dedup)` — same user, same flag, two different group contexts → two events.
- `$feature_flag_called dedupes across repeated calls under the same group context` — repeated access under the same group → one event.
- `$feature_flag_called dedupes when same groups are passed in different key order` — same groups passed with keys in a different order → one event (canonicalized via `groups.sort.to_json`).

All 78 existing client tests pass, and all 35 `feature_flag_evaluations_spec` tests pass.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*