### PR TITLE
docs: remove experimental flag definition cache labels

### DIFF
--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -72,7 +72,7 @@ module PostHog
     # @option opts [Boolean] :skip_ssl_verification +true+ to disable SSL certificate verification for requests.
     #   Intended only for local development or custom deployments.
     # @option opts [Object] :flag_definition_cache_provider An object implementing the {FlagDefinitionCacheProvider}
-    #   interface for distributed flag definition caching. EXPERIMENTAL: This API may change in future minor versions.
+    #   interface for distributed flag definition caching.
     def initialize(opts = {})
       symbolize_keys!(opts)
 

--- a/lib/posthog/flag_definition_cache.rb
+++ b/lib/posthog/flag_definition_cache.rb
@@ -3,8 +3,6 @@
 module PostHog
   # Interface for external caching of feature flag definitions.
   #
-  # EXPERIMENTAL: This API may change in future minor version bumps.
-  #
   # Enables multi-worker environments (Kubernetes, load-balanced servers,
   # serverless functions) to share flag definitions via an external cache,
   # reducing redundant API calls.


### PR DESCRIPTION
## :bulb: Motivation and Context

The flag definition cache provider is now supported and should no longer be documented as experimental.

Companion Python PR: https://github.com/PostHog/posthog-python/pull/631
Docs PR: https://github.com/PostHog/posthog.com/pull/17075

## :green_heart: How did you test it?

Verified there are no remaining `experimental` references.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
