### PR TITLE
fix(rails): exclude MimeNegotiation::InvalidType by default

### DIFF
--- a/.changeset/exclude-mime-negotiation-invalidtype.md
+++ b/.changeset/exclude-mime-negotiation-invalidtype.md
@@ -1,0 +1,5 @@
+---
+'posthog-ruby': patch
+---
+
+posthog-rails: exclude `ActionDispatch::Http::MimeNegotiation::InvalidType` from captured exceptions by default. It is raised on malformed `Accept`/`Content-Type` headers (almost always scanner traffic) and mapped to a 406 by Rails, so it is noise rather than an app error.

--- a/posthog-rails/lib/generators/posthog/templates/posthog.rb
+++ b/posthog-rails/lib/generators/posthog/templates/posthog.rb
@@ -130,6 +130,7 @@ end
 # - ActionController::RoutingError
 # - ActionController::UnknownFormat
 # - ActionController::UnknownHttpMethod
+# - ActionDispatch::Http::MimeNegotiation::InvalidType
 # - ActionDispatch::Http::Parameters::ParseError
 # - ActiveRecord::RecordNotFound
 # - ActiveRecord::RecordNotUnique

--- a/posthog-rails/lib/posthog/rails/configuration.rb
+++ b/posthog-rails/lib/posthog/rails/configuration.rb
@@ -56,6 +56,7 @@ module PostHog
           'ActionController::RoutingError',
           'ActionController::UnknownFormat',
           'ActionController::UnknownHttpMethod',
+          'ActionDispatch::Http::MimeNegotiation::InvalidType',
           'ActionDispatch::Http::Parameters::ParseError',
           'ActiveRecord::RecordNotFound',
           'ActiveRecord::RecordNotUnique'

--- a/spec/posthog/rails/configuration_spec.rb
+++ b/spec/posthog/rails/configuration_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'action_controller'
+require 'action_dispatch'
+
+$LOAD_PATH.unshift File.expand_path('../../../posthog-rails/lib', __dir__)
+
+require 'posthog/rails/configuration'
+
+RSpec.describe PostHog::Rails::Configuration do
+  subject(:config) { described_class.new }
+
+  describe '#should_capture_exception?' do
+    it 'excludes ActionController::RoutingError by default' do
+      exception = ActionController::RoutingError.new('No route matches')
+      expect(config.should_capture_exception?(exception)).to be false
+    end
+
+    it 'excludes ActionDispatch::Http::MimeNegotiation::InvalidType by default' do
+      # Raised when a client sends a malformed Accept / Content-Type header
+      # (typically scanner traffic). Rails maps it to a 406 — see
+      # ActionDispatch::ExceptionWrapper.rescue_responses — so it is not a
+      # bug worth capturing.
+      exception = ActionDispatch::Http::MimeNegotiation::InvalidType.new('"foo" is not a valid MIME type')
+      expect(config.should_capture_exception?(exception)).to be false
+    end
+
+    it 'captures application exceptions that are not in the excluded list' do
+      exception = StandardError.new('something broke')
+      expect(config.should_capture_exception?(exception)).to be true
+    end
+
+    it 'honours user-supplied excluded_exceptions in addition to defaults' do
+      config.excluded_exceptions = ['MyApp::IgnorableError']
+      stub_const('MyApp::IgnorableError', Class.new(StandardError))
+      expect(config.should_capture_exception?(MyApp::IgnorableError.new)).to be false
+      # defaults still apply
+      expect(config.should_capture_exception?(ActionController::RoutingError.new('x'))).to be false
+    end
+  end
+end

--- a/spec/posthog/rails/configuration_spec.rb
+++ b/spec/posthog/rails/configuration_spec.rb
@@ -12,18 +12,18 @@ RSpec.describe PostHog::Rails::Configuration do
   subject(:config) { described_class.new }
 
   describe '#should_capture_exception?' do
-    it 'excludes ActionController::RoutingError by default' do
-      exception = ActionController::RoutingError.new('No route matches')
-      expect(config.should_capture_exception?(exception)).to be false
-    end
-
-    it 'excludes ActionDispatch::Http::MimeNegotiation::InvalidType by default' do
-      # Raised when a client sends a malformed Accept / Content-Type header
-      # (typically scanner traffic). Rails maps it to a 406 — see
-      # ActionDispatch::ExceptionWrapper.rescue_responses — so it is not a
-      # bug worth capturing.
-      exception = ActionDispatch::Http::MimeNegotiation::InvalidType.new('"foo" is not a valid MIME type')
-      expect(config.should_capture_exception?(exception)).to be false
+    # MimeNegotiation::InvalidType is raised when a client sends a malformed
+    # Accept / Content-Type header (typically scanner traffic). Rails maps it
+    # to a 406 — see ActionDispatch::ExceptionWrapper.rescue_responses — so it
+    # is not a bug worth capturing.
+    {
+      'ActionController::RoutingError' => ActionController::RoutingError.new('No route matches'),
+      'ActionDispatch::Http::MimeNegotiation::InvalidType' =>
+        ActionDispatch::Http::MimeNegotiation::InvalidType.new('"foo" is not a valid MIME type')
+    }.each do |name, exception|
+      it "excludes #{name} by default" do
+        expect(config.should_capture_exception?(exception)).to be false
+      end
     end
 
     it 'captures application exceptions that are not in the excluded list' do


### PR DESCRIPTION
Closes #159.

`MimeNegotiation::InvalidType` is raised when a client sends a malformed `Accept` / `Content-Type` header, almost always scanner traffic. Rails maps it to a 406 via `ActionDispatch::ExceptionWrapper.rescue_responses`, so it's not an app bug. Same category as the already-excluded `BadRequest` / `UnknownFormat` / `ParseError`.

- Adds the class to `default_excluded_exceptions`
- Updates the generator template's docs
- Adds `spec/posthog/rails/configuration_spec.rb`

`bundle exec rspec` and `bundle exec rubocop` pass locally.