### PR TITLE
feat: emit $is_server property on captured events

### DIFF
--- a/.changeset/is-server-property.md
+++ b/.changeset/is-server-property.md
@@ -2,4 +2,4 @@
 "posthog-ruby": patch
 ---
 
-Emit `$is_server` property on captured events so PostHog can identify server-side events.
+Add a configurable `$is_server` event property (default `true`) so PostHog can identify server-side events. Set `is_server: false` when using posthog-ruby as a client/CLI so the device OS is attributed normally.

--- a/.changeset/is-server-property.md
+++ b/.changeset/is-server-property.md
@@ -1,5 +1,5 @@
 ---
-"posthog-ruby": patch
+"posthog-ruby": minor
 ---
 
 Add a configurable `$is_server` event property (default `true`) so PostHog can identify server-side events. Set `is_server: false` when using posthog-ruby as a client/CLI so the device OS is attributed normally.

--- a/.changeset/is-server-property.md
+++ b/.changeset/is-server-property.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": patch
+---
+
+Emit `$is_server` property on captured events so PostHog can identify server-side events.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -73,6 +73,9 @@ module PostHog
     #   Intended only for local development or custom deployments.
     # @option opts [Object] :flag_definition_cache_provider An object implementing the {FlagDefinitionCacheProvider}
     #   interface for distributed flag definition caching.
+    # @option opts [Boolean] :is_server +true+ to stamp captured events with `$is_server => true` so PostHog
+    #   attributes them as server-side. Defaults to +true+. Set to +false+ when running posthog-ruby as a
+    #   client/CLI so the device OS is attributed normally and `$is_server` is omitted.
     def initialize(opts = {})
       symbolize_keys!(opts)
 
@@ -141,6 +144,7 @@ module PostHog
       end
 
       @before_send = opts[:before_send]
+      @is_server = opts.fetch(:is_server, true) != false
       @deprecation_emitted_for = Concurrent::Set.new
     end
 
@@ -272,6 +276,7 @@ module PostHog
         attrs[:feature_variants] = feature_variants if feature_variants
       end
 
+      attrs[:is_server] = @is_server
       enqueue(FieldParser.parse_for_capture(attrs))
     end
 
@@ -317,6 +322,7 @@ module PostHog
       return false if @disabled
 
       symbolize_keys! attrs
+      attrs[:is_server] = @is_server
       enqueue(FieldParser.parse_for_identify(attrs))
     end
 
@@ -334,6 +340,7 @@ module PostHog
       return false if @disabled
 
       symbolize_keys! attrs
+      attrs[:is_server] = @is_server
       enqueue(FieldParser.parse_for_group_identify(attrs))
     end
 
@@ -348,6 +355,7 @@ module PostHog
       return false if @disabled
 
       symbolize_keys! attrs
+      attrs[:is_server] = @is_server
       enqueue(FieldParser.parse_for_alias(attrs))
     end
 

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -149,7 +149,8 @@ module PostHog
           distinct_id: distinct_id,
           properties: {
             '$lib' => 'posthog-ruby',
-            '$lib_version' => PostHog::VERSION.to_s
+            '$lib_version' => PostHog::VERSION.to_s,
+            '$is_server' => true
           }
         }
 

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -141,17 +141,23 @@ module PostHog
         check_timestamp! timestamp
         check_presence! distinct_id, 'distinct_id'
 
+        # Default to true so direct callers (and the historical behavior) still mark events
+        # as server-side; the client passes is_server: false to opt out.
+        is_server = fields.fetch(:is_server, true) != false
+
+        properties = {
+          '$lib' => 'posthog-ruby',
+          '$lib_version' => PostHog::VERSION.to_s
+        }
+        properties['$is_server'] = true if is_server
+
         parsed = {
           timestamp: datetime_in_iso8601(timestamp),
           library: 'posthog-ruby',
           library_version: PostHog::VERSION.to_s,
           messageId: message_id,
           distinct_id: distinct_id,
-          properties: {
-            '$lib' => 'posthog-ruby',
-            '$lib_version' => PostHog::VERSION.to_s,
-            '$is_server' => true
-          }
+          properties: properties
         }
 
         if send_feature_flags && fields[:feature_variants]

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -89,11 +89,11 @@ module PostHog
         common.merge(
           {
             event: '$groupidentify',
-            properties: {
+            properties: (common[:properties] || {}).merge(
               '$group_type': group_type,
               '$group_key': group_key,
-              '$group_set': properties.merge(common[:properties] || {})
-            }
+              '$group_set': properties
+            )
           }
         )
       end
@@ -141,8 +141,6 @@ module PostHog
         check_timestamp! timestamp
         check_presence! distinct_id, 'distinct_id'
 
-        # Default to true so direct callers (and the historical behavior) still mark events
-        # as server-side; the client passes is_server: false to opt out.
         is_server = fields.fetch(:is_server, true) != false
 
         properties = {

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -271,6 +271,14 @@ module PostHog
         expect(message[:properties]['$is_server']).to be true
       end
 
+      it 'omits $is_server when initialized with is_server: false' do
+        client = Client.new(api_key: API_KEY, test_mode: true, is_server: false)
+        client.capture(distinct_id: 'user', event: 'Event')
+
+        message = client.dequeue_last_message
+        expect(message[:properties]).not_to have_key('$is_server')
+      end
+
       it 'errors if properties is not a hash' do
         expect do
           client.capture(

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1378,8 +1378,8 @@ module PostHog
         client.group_identify(group_type: 'organization', group_key: 'id:5', properties: { trait: 'value' })
         msg = client.dequeue_last_message
 
-        expect(msg[:properties][:$is_server]).to be true
-        expect(msg[:properties][:$group_set]).not_to have_key(:$is_server)
+        expect(msg[:properties]['$is_server']).to be true
+        expect(msg[:properties][:$group_set]).not_to have_key('$is_server')
       end
     end
 

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -264,6 +264,13 @@ module PostHog
         expect(message[:properties]['$process_person_profile']).to be true
       end
 
+      it 'sets $is_server to true on captured events' do
+        client.capture(distinct_id: 'user', event: 'Event')
+
+        message = client.dequeue_last_message
+        expect(message[:properties]['$is_server']).to be true
+      end
+
       it 'errors if properties is not a hash' do
         expect do
           client.capture(
@@ -504,6 +511,7 @@ module PostHog
             '$feature_flag_response' => true,
             '$lib' => 'posthog-ruby',
             '$lib_version' => '1.2.4',
+            '$is_server' => true,
             '$groups' => {},
             'locally_evaluated' => true
           )

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1373,6 +1373,14 @@ module PostHog
         expect(msg[:properties][:$group_type]).to eq('organization')
         expect(msg[:properties][:$group_set][:trait]).to eq('value')
       end
+
+      it 'sets $is_server at the top level, not inside $group_set' do
+        client.group_identify(group_type: 'organization', group_key: 'id:5', properties: { trait: 'value' })
+        msg = client.dequeue_last_message
+
+        expect(msg[:properties][:$is_server]).to be true
+        expect(msg[:properties][:$group_set]).not_to have_key(:$is_server)
+      end
     end
 
     describe '#alias' do

--- a/spec/posthog/flags_spec.rb
+++ b/spec/posthog/flags_spec.rb
@@ -356,6 +356,7 @@ module PostHog
                '$feature_flag_evaluated_at' => 1_704_067_200_000,
                '$lib' => 'posthog-ruby',
                '$lib_version' => '2.8.0',
+               '$is_server' => true,
                '$groups' => {},
                'locally_evaluated' => false
              })


### PR DESCRIPTION
Adds `$is_server: true` to every event captured by this SDK so PostHog ingestion can identify server-side events.