### PR TITLE
chore: add Sentry license attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Some files in this codebase contain code from getsentry/sentry-ruby by Software, Inc. dba Sentry.
+In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
+
+MIT License
+
+Copyright (c) 2020 Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/posthog-rails/lib/posthog/rails/configuration.rb
+++ b/posthog-rails/lib/posthog/rails/configuration.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Portions of this file are derived from getsentry/sentry-ruby by Software, Inc. dba Sentry
+# Licensed under the MIT License
+
 module PostHog
   module Rails
     class Configuration

--- a/posthog-rails/lib/posthog/rails/parameter_filter.rb
+++ b/posthog-rails/lib/posthog/rails/parameter_filter.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Portions of this file are derived from getsentry/sentry-ruby by Software, Inc. dba Sentry
+# Licensed under the MIT License
+
 module PostHog
   module Rails
     # Shared utility module for filtering sensitive parameters

--- a/posthog-rails/lib/posthog/rails/rescued_exception_interceptor.rb
+++ b/posthog-rails/lib/posthog/rails/rescued_exception_interceptor.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Portions of this file are derived from getsentry/sentry-ruby by Software, Inc. dba Sentry
+# Licensed under the MIT License
+
 module PostHog
   module Rails
     # Middleware that intercepts exceptions that are rescued by Rails.


### PR DESCRIPTION
## :bulb: Motivation and Context

Add explicit attribution for portions of the codebase derived from getsentry/sentry-ruby and include the relevant Sentry MIT license text in the repository license file.

## :green_heart: How did you test it?

- `git diff --check`
- `ruby -c posthog-rails/lib/posthog/rails/configuration.rb`
- `ruby -c posthog-rails/lib/posthog/rails/parameter_filter.rb`
- `ruby -c posthog-rails/lib/posthog/rails/rescued_exception_interceptor.rb`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
