### PR TITLE
chore: clarify Sentry license attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,10 +22,10 @@ SOFTWARE.
 
 ---
 
-Some files in this codebase contain code from getsentry/sentry-ruby by Software, Inc. dba Sentry.
+Some files in this codebase contain code from getsentry/sentry-ruby.
 In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
 
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2020 Sentry
 
@@ -36,13 +36,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lib/posthog/exception_capture.rb
+++ b/lib/posthog/exception_capture.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-# Portions of this file are derived from getsentry/sentry-ruby by Software, Inc. dba Sentry
-# Licensed under the MIT License
+# Portions of this file are derived from getsentry/sentry-ruby
+# Copyright (c) 2020 Sentry
+# Licensed under the MIT License: https://github.com/getsentry/sentry-ruby/blob/master/LICENSE
 # - sentry-ruby/lib/sentry/interfaces/single_exception.rb
 # - sentry-ruby/lib/sentry/interfaces/stacktrace_builder.rb
 # - sentry-ruby/lib/sentry/backtrace.rb

--- a/posthog-rails/lib/posthog/rails/configuration.rb
+++ b/posthog-rails/lib/posthog/rails/configuration.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-# Portions of this file are derived from getsentry/sentry-ruby by Software, Inc. dba Sentry
-# Licensed under the MIT License
+# Portions of this file are derived from getsentry/sentry-ruby
+# Copyright (c) 2020 Sentry
+# Licensed under the MIT License: https://github.com/getsentry/sentry-ruby/blob/master/LICENSE
 
 module PostHog
   module Rails

--- a/posthog-rails/lib/posthog/rails/parameter_filter.rb
+++ b/posthog-rails/lib/posthog/rails/parameter_filter.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-# Portions of this file are derived from getsentry/sentry-ruby by Software, Inc. dba Sentry
-# Licensed under the MIT License
+# Portions of this file are derived from getsentry/sentry-ruby
+# Copyright (c) 2020 Sentry
+# Licensed under the MIT License: https://github.com/getsentry/sentry-ruby/blob/master/LICENSE
 
 module PostHog
   module Rails

--- a/posthog-rails/lib/posthog/rails/rescued_exception_interceptor.rb
+++ b/posthog-rails/lib/posthog/rails/rescued_exception_interceptor.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-# Portions of this file are derived from getsentry/sentry-ruby by Software, Inc. dba Sentry
-# Licensed under the MIT License
+# Portions of this file are derived from getsentry/sentry-ruby
+# Copyright (c) 2020 Sentry
+# Licensed under the MIT License: https://github.com/getsentry/sentry-ruby/blob/master/LICENSE
 
 module PostHog
   module Rails


### PR DESCRIPTION
## :bulb: Motivation and Context

Clarifies attribution for the portions of the Ruby and Rails exception-capture code derived from `getsentry/sentry-ruby`, including the Sentry copyright notice and MIT license link.

## :green_heart: How did you test it?

Not run; license/header-only change.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
