### PR TITLE
chore: add public API baseline probe

### DIFF
--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -176,6 +176,13 @@ module PostHog
       @queue.clear
     end
 
+    # Temporary public API used to verify that CI detects snapshot drift.
+    #
+    # @return [Boolean]
+    def public_api_ci_probe
+      true
+    end
+
     # @!macro common_attrs
     #   @option attrs [String] :message_id ID that uniquely
     #     identifies a message across the API. (optional)


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adds a small public API without updating `public_api_snapshot.txt` so the new public API baseline CI check can be validated on a draft PR.

## :green_heart: How did you test it?

- `bundle exec rubocop lib/posthog/client.rb`
- `bundle exec rake public_api:check` (expected failure: reports `PostHog::Client#public_api_ci_probe()` missing from the snapshot)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
