### PR TITLE
fix: use canonical feature flag user agent

### DIFF
--- a/.changeset/fix-feature-flag-user-agent.md
+++ b/.changeset/fix-feature-flag-user-agent.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": patch
+---
+
+Send the canonical `posthog-ruby/<version>` User-Agent on feature flag API requests.

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -1242,7 +1242,7 @@ module PostHog
 
     # rubocop:disable Lint/ShadowedException
     def _request(uri, request_object, timeout = nil, include_etag: false)
-      request_object['User-Agent'] = "posthog-ruby#{PostHog::VERSION}"
+      request_object['User-Agent'] = "posthog-ruby/#{PostHog::VERSION}"
       request_timeout = timeout || 10
 
       begin

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -4818,7 +4818,7 @@ module PostHog
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
           'Host' => 'us.i.posthog.com',
-          'User-Agent' => "posthog-ruby#{PostHog::VERSION}"
+          'User-Agent' => "posthog-ruby/#{PostHog::VERSION}"
         }
       ).to_return(status: 200, body: '{"featureFlags": {}}', headers: {})
 

--- a/spec/posthog/flags_spec.rb
+++ b/spec/posthog/flags_spec.rb
@@ -24,7 +24,7 @@ module PostHog
             'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Authorization' => 'Bearer testsecret',
             'Host' => 'us.i.posthog.com',
-            'User-Agent' => "posthog-ruby#{PostHog::VERSION}"
+            'User-Agent' => "posthog-ruby/#{PostHog::VERSION}"
           }
         )
         .to_return(status: 200, body: { flags: [] }.to_json)
@@ -398,7 +398,7 @@ module PostHog
             'Content-Type' => 'application/json',
             'Authorization' => 'Bearer personal_key',
             'Host' => 'us.i.posthog.com',
-            'User-Agent' => "posthog-ruby#{PostHog::VERSION}"
+            'User-Agent' => "posthog-ruby/#{PostHog::VERSION}"
           }
         )
         .to_return(status: 200, body: remote_config_response.to_json)
@@ -816,7 +816,7 @@ module PostHog
             'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
             'Authorization' => 'Bearer testsecret',
             'Host' => 'us.i.posthog.com',
-            'User-Agent' => "posthog-ruby#{PostHog::VERSION}"
+            'User-Agent' => "posthog-ruby/#{PostHog::VERSION}"
           }
         )
         .to_return(status: 200, body: { flags: [] }.to_json)


### PR DESCRIPTION
## :bulb: Motivation and Context
Feature flag API requests currently send a `User-Agent` like `posthog-ruby<version>`, which is missing the separator used by the canonical SDK user agent format.

This fixes those requests to send `posthog-ruby/<version>`.


## :green_heart: How did you test it?

- `bundle exec rubocop lib/posthog/feature_flags.rb spec/posthog/flags_spec.rb spec/posthog/feature_flag_spec.rb`
- `bundle exec rspec spec/posthog/flags_spec.rb spec/posthog/feature_flag_spec.rb`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
