### PR TITLE
fix: Harden Ruby SDK thread lifecycle handling

### DIFF
--- a/.changeset/calm-ravens-rest.md
+++ b/.changeset/calm-ravens-rest.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": patch
+---
+
+Harden async worker, shutdown, queue, and feature flag cache behavior for threaded Ruby and Rails apps.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -84,10 +84,13 @@ module PostHog
       opts[:host] = normalize_host_option(opts[:host])
 
       @queue = Queue.new
+      @queue_mutex = Mutex.new
       @api_key = opts[:api_key]
       @disabled = @api_key.nil? || @api_key.empty?
       @max_queue_size = opts[:max_queue_size] || Defaults::Queue::MAX_SIZE
       @worker_mutex = Mutex.new
+      @shutdown_mutex = Mutex.new
+      @shutdown = false
       @sync_mode = opts[:sync_mode] == true && !opts[:test_mode] && !@disabled
       @on_error = opts[:on_error] || proc { |status, error| }
       @worker = if opts[:test_mode] || @disabled
@@ -139,8 +142,9 @@ module PostHog
           )
       end
 
+      @distinct_id_has_sent_flag_calls_mutex = Mutex.new
       @distinct_id_has_sent_flag_calls = SizeLimitedHash.new(Defaults::MAX_HASH_SIZE) do |hash, key|
-        hash[key] = []
+        hash[key] = SizeLimitedArray.new(Defaults::MAX_HASH_SIZE)
       end
 
       @before_send = opts[:before_send]
@@ -173,7 +177,7 @@ module PostHog
     #
     # @return [void]
     def clear
-      @queue.clear
+      @queue_mutex.synchronize { @queue.clear }
     end
 
     # @!macro common_attrs
@@ -757,6 +761,16 @@ module PostHog
     #
     # @return [void]
     def shutdown
+      already_shutdown = @shutdown_mutex.synchronize do
+        if @shutdown
+          true
+        else
+          @shutdown = true
+          false
+        end
+      end
+      return if already_shutdown
+
       self.class._decrement_instance_count(@api_key) unless @disabled
       @feature_flags_poller&.shutdown_poller
       flush
@@ -764,6 +778,7 @@ module PostHog
         @sync_lock.synchronize { @transport&.shutdown }
       else
         @worker&.shutdown
+        @worker_thread&.join(1)
       end
     end
 
@@ -821,7 +836,16 @@ module PostHog
           ''
         end
       reported_key = "#{key}_#{response_repr}#{groups_repr}"
-      return if @distinct_id_has_sent_flag_calls[distinct_id].include?(reported_key)
+      should_capture = @distinct_id_has_sent_flag_calls_mutex.synchronize do
+        sent_keys = @distinct_id_has_sent_flag_calls[distinct_id]
+        if sent_keys.include?(reported_key)
+          false
+        else
+          sent_keys << reported_key
+          true
+        end
+      end
+      return unless should_capture
 
       msg = {
         distinct_id: distinct_id,
@@ -832,7 +856,6 @@ module PostHog
       msg[:disable_geoip] = disable_geoip unless disable_geoip.nil?
 
       capture(msg)
-      @distinct_id_has_sent_flag_calls[distinct_id] << reported_key
     end
 
     def _feature_flag_evaluations_host
@@ -921,7 +944,7 @@ module PostHog
     #
     # returns Boolean of whether the item was added to the queue.
     def enqueue(action)
-      return false if @disabled
+      return false if @disabled || shutdown?
 
       action = process_before_send(action)
       return false if action.nil? || action.empty?
@@ -934,10 +957,17 @@ module PostHog
         return true
       end
 
-      if @queue.length < @max_queue_size
-        @queue << action
-        ensure_worker_running
+      queued = @queue_mutex.synchronize do
+        if @queue.length < @max_queue_size
+          @queue << action
+          true
+        else
+          false
+        end
+      end
 
+      if queued
+        ensure_worker_running
         true
       else
         logger.warn(
@@ -993,6 +1023,10 @@ module PostHog
 
     def worker_running?
       @worker_thread&.alive?
+    end
+
+    def shutdown?
+      @shutdown_mutex.synchronize { @shutdown }
     end
 
     def add_local_person_and_group_properties(distinct_id, groups, person_properties, group_properties)

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -1250,7 +1250,9 @@ module PostHog
           uri.hostname,
           uri.port,
           use_ssl: uri.scheme == 'https',
-          read_timeout: request_timeout
+          open_timeout: request_timeout,
+          read_timeout: request_timeout,
+          write_timeout: request_timeout
         ) do |http|
           res = http.request(request_object)
           status_code = res.code.to_i

--- a/lib/posthog/send_worker.rb
+++ b/lib/posthog/send_worker.rb
@@ -60,6 +60,9 @@ module PostHog
         end
       end
     ensure
+      # Worker threads exit when the queue is drained and are restarted for the
+      # next burst of events. Close the persistent connection on each exit and
+      # let Transport reconnect lazily when a future worker sends another batch.
       @transport.shutdown
     end
 

--- a/lib/posthog/send_worker.rb
+++ b/lib/posthog/send_worker.rb
@@ -34,6 +34,8 @@ module PostHog
       batch_size = options[:batch_size] || Defaults::MessageBatch::MAX_SIZE
       @batch = MessageBatch.new(batch_size)
       @lock = Mutex.new
+      @shutdown_mutex = Mutex.new
+      @shutdown = false
       @transport = Transport.new api_host: options[:host], skip_ssl_verification: options[:skip_ssl_verification]
     end
 
@@ -41,19 +43,21 @@ module PostHog
     #
     # @return [void]
     def run
-      until Thread.current[:should_exit]
+      until shutdown?
         return if @queue.empty?
 
         @lock.synchronize do
           consume_message_from_queue! until @batch.full? || @queue.empty?
         end
 
-        unless @batch.empty?
-          res = @transport.send @api_key, @batch
-          @on_error.call(res.status, res.error) unless res.status == 200
+        begin
+          unless @batch.empty?
+            res = @transport.send @api_key, @batch
+            handle_error(res.status, res.error) unless res.status == 200
+          end
+        ensure
+          @lock.synchronize { @batch.clear }
         end
-
-        @lock.synchronize { @batch.clear }
       end
     ensure
       @transport.shutdown
@@ -61,6 +65,7 @@ module PostHog
 
     # @return [void]
     def shutdown
+      @shutdown_mutex.synchronize { @shutdown = true }
       @transport.shutdown
     end
 
@@ -74,10 +79,20 @@ module PostHog
 
     private
 
+    def shutdown?
+      @shutdown_mutex.synchronize { @shutdown }
+    end
+
     def consume_message_from_queue!
       @batch << @queue.pop
     rescue MessageBatch::JSONGenerationError => e
-      @on_error.call(-1, e.to_s)
+      handle_error(-1, e.to_s)
+    end
+
+    def handle_error(status, error)
+      @on_error.call(status, error)
+    rescue StandardError => e
+      logger.error("Error in on_error callback: #{e.message}")
     end
   end
 end

--- a/lib/posthog/transport.rb
+++ b/lib/posthog/transport.rb
@@ -52,6 +52,7 @@ module PostHog
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE if options[:skip_ssl_verification]
 
       @http = http
+      @http_mutex = Mutex.new
     end
 
     # Sends a batch of messages to the API
@@ -91,7 +92,9 @@ module PostHog
     #
     # @return [void]
     def shutdown
-      @http.finish if @http.started?
+      @http_mutex.synchronize do
+        @http.finish if @http.started?
+      end
     end
 
     private
@@ -149,9 +152,11 @@ module PostHog
 
         [200, '{}']
       else
-        @http.start unless @http.started? # Maintain a persistent connection
-        response = @http.request(request, payload)
-        [response.code.to_i, response.body]
+        @http_mutex.synchronize do
+          @http.start unless @http.started? # Maintain a persistent connection
+          response = @http.request(request, payload)
+          [response.code.to_i, response.body]
+        end
       end
     end
 

--- a/lib/posthog/utils.rb
+++ b/lib/posthog/utils.rb
@@ -166,5 +166,24 @@ module PostHog
         super
       end
     end
+
+    # Array that drops the oldest item when it reaches a maximum length.
+    #
+    # @api private
+    class SizeLimitedArray < Array
+      # @param max_length [Integer]
+      def initialize(max_length)
+        super()
+        @max_length = max_length
+      end
+
+      # @param value [Object]
+      # @return [Array]
+      def <<(value)
+        shift if length >= @max_length
+        super
+      end
+    end
+    private_constant :SizeLimitedArray
   end
 end

--- a/posthog-rails/lib/posthog/rails/railtie.rb
+++ b/posthog-rails/lib/posthog/rails/railtie.rb
@@ -39,7 +39,14 @@ module PostHog
               PostHog::Rails::Logs::Setup.remember_client_options(options) if defined?(PostHog::Rails::Logs::Setup)
 
               # Create the PostHog client
+              previous_client = @client
               @client = PostHog::Client.new(options)
+              begin
+                previous_client&.shutdown
+              rescue StandardError => e
+                PostHog::Logging.logger.warn("Failed to shut down previous PostHog client: #{e.message}")
+              end
+              @client
             end
 
             # Define delegated methods using metaprogramming

--- a/posthog-rails/lib/posthog/rails/railtie.rb
+++ b/posthog-rails/lib/posthog/rails/railtie.rb
@@ -38,7 +38,9 @@ module PostHog
               # the core client exposing public readers.
               PostHog::Rails::Logs::Setup.remember_client_options(options) if defined?(PostHog::Rails::Logs::Setup)
 
-              # Create the PostHog client
+              # Create the PostHog client. If a client already exists, shut it down
+              # after replacement so repeated init calls do not leave background
+              # resources from the previous instance running.
               previous_client = @client
               @client = PostHog::Client.new(options)
               begin

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1736,6 +1736,9 @@ module PostHog
         class << queue
           alias_method :original_length_for_concurrency_spec, :length
 
+          # Widen the old check-then-push TOCTOU window. The production fix holds
+          # @queue_mutex across both this length check and the subsequent push, so
+          # concurrent producers cannot observe the same stale queue length.
           def length
             value = original_length_for_concurrency_spec
             Thread.pass

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1464,6 +1464,18 @@ module PostHog
       end
     end
 
+    describe '#shutdown' do
+      it 'is idempotent and stops accepting new events' do
+        worker = instance_spy(PostHog::NoopWorker, is_requesting?: false)
+        client.instance_variable_set(:@worker, worker)
+
+        expect { 2.times { client.shutdown } }.to_not raise_error
+
+        expect(worker).to have_received(:shutdown).once
+        expect(client.capture(Queued::CAPTURE)).to eq(false)
+      end
+    end
+
     describe 'feature flags' do
       it 'returns defaults without requests when the client is disabled' do
         disabled_client = Client.new(api_key: " \n\t ", test_mode: true)
@@ -1715,6 +1727,29 @@ module PostHog
           expect(client.send(s, data)).to eq(false) # Queue is full
           client.clear
         end
+      end
+
+      it 'does not exceed max queue size with concurrent producers' do
+        client.instance_variable_set(:@max_queue_size, 1)
+        queue = client.instance_variable_get(:@queue)
+
+        class << queue
+          alias_method :original_length_for_concurrency_spec, :length
+
+          def length
+            value = original_length_for_concurrency_spec
+            Thread.pass
+            sleep 0.001
+            value
+          end
+        end
+
+        threads = 20.times.map do |index|
+          Thread.new { client.capture(event: 'concurrent', distinct_id: index.to_s) }
+        end
+        threads.each(&:join)
+
+        expect(queue.length).to eq(1)
       end
 
       it 'converts message id to string' do

--- a/spec/posthog/flags_spec.rb
+++ b/spec/posthog/flags_spec.rb
@@ -1939,4 +1939,25 @@ module PostHog
       end
     end
   end
+
+  describe FeatureFlagsPoller do
+    it 'applies open, read, and write timeouts to feature flag requests' do
+      poller = described_class.allocate
+      uri = URI('https://example.com/flags')
+      request = Net::HTTP::Get.new(uri)
+      response = double('response', code: '200', body: '{}')
+      http = double('http', request: response)
+
+      expect(Net::HTTP).to receive(:start).with(
+        'example.com',
+        443,
+        use_ssl: true,
+        open_timeout: 7,
+        read_timeout: 7,
+        write_timeout: 7
+      ).and_yield(http)
+
+      expect(poller.send(:_request, uri, request, 7)).to eq(status: 200)
+    end
+  end
 end

--- a/spec/posthog/rails/railtie_spec.rb
+++ b/spec/posthog/rails/railtie_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe PostHog::Rails::Railtie do
       expect(PostHog.evaluate_flags('user').keys).to eq([])
       expect(logger).not_to have_received(:error)
     end
+
+    it 'shuts down the previous client when init is called again' do
+      previous_client = instance_spy(PostHog::Client)
+      PostHog.client = previous_client
+
+      new_client = PostHog.init(api_key: 'testsecret', test_mode: true)
+
+      expect(new_client).to be_a(PostHog::Client)
+      expect(PostHog.client).to eq(new_client)
+      expect(previous_client).to have_received(:shutdown).once
+    end
   end
 
   describe 'posthog.insert_middlewares initializer' do

--- a/spec/posthog/send_worker_spec.rb
+++ b/spec/posthog/send_worker_spec.rb
@@ -73,13 +73,15 @@ module PostHog
       end
 
       it 'clears the in-flight batch if the error handler raises' do
-        allow_any_instance_of(PostHog::Transport).to(
-          receive(:send).and_return(PostHog::Response.new(400, 'Some error'))
-        )
-
         queue = Queue.new
         queue << {}
         worker = described_class.new(queue, 'secret', on_error: proc { raise 'handler failed' })
+        transport = instance_double(
+          PostHog::Transport,
+          send: PostHog::Response.new(400, 'Some error'),
+          shutdown: nil
+        )
+        worker.instance_variable_set(:@transport, transport)
 
         expect { worker.run }.to_not raise_error
         expect(queue).to be_empty

--- a/spec/posthog/send_worker_spec.rb
+++ b/spec/posthog/send_worker_spec.rb
@@ -72,6 +72,20 @@ module PostHog
         expect(error).to eq('Some error')
       end
 
+      it 'clears the in-flight batch if the error handler raises' do
+        allow_any_instance_of(PostHog::Transport).to(
+          receive(:send).and_return(PostHog::Response.new(400, 'Some error'))
+        )
+
+        queue = Queue.new
+        queue << {}
+        worker = described_class.new(queue, 'secret', on_error: proc { raise 'handler failed' })
+
+        expect { worker.run }.to_not raise_error
+        expect(queue).to be_empty
+        expect(worker.is_requesting?).to eq(false)
+      end
+
       it 'does not call on_error if the request is good' do
         on_error = proc { |status, error| puts "#{status}, #{error}" }
 

--- a/spec/posthog/transport_spec.rb
+++ b/spec/posthog/transport_spec.rb
@@ -110,6 +110,16 @@ module PostHog
       end
     end
 
+    describe '#shutdown' do
+      it 'is idempotent' do
+        http = subject.instance_variable_get(:@http)
+        allow(http).to receive(:started?).and_return(true, false)
+        expect(http).to receive(:finish).once
+
+        2.times { subject.shutdown }
+      end
+    end
+
     describe '#send' do
       let(:response) do
         Net::HTTPResponse.new(http_version, status_code, response_body)

--- a/spec/posthog/utils_spec.rb
+++ b/spec/posthog/utils_spec.rb
@@ -33,6 +33,17 @@ module PostHog
         expect(dict.length <= size).to eq(true)
       end
     end
+
+    it 'size limited array drops oldest entries without exposing the constant publicly' do
+      expect { PostHog::Utils::SizeLimitedArray }.to raise_error(NameError)
+
+      array_class = PostHog::Utils.const_get(:SizeLimitedArray, false)
+      array = array_class.new(3)
+
+      (1..5).each { |i| array << i }
+
+      expect(array).to eq([3, 4, 5])
+    end
   end
 
   describe '.get_by_symbol_or_string_key' do


### PR DESCRIPTION
## :bulb: Motivation and Context

A Rails user raised concerns that the Ruby SDK may not be reliable in threaded Rails apps, including possible race conditions, memory growth, and hanging worker threads. I audited the async worker, queue handling, shutdown path, feature flag polling/cache paths, and Rails singleton initialization, then hardened the concrete issues found.

Findings addressed:

- A user-provided `on_error` callback could raise while the send worker had an in-flight batch. That left `is_requesting?` true and could make `flush`/Rails `at_exit` shutdown wait forever.
- Repeated `PostHog.init` calls in Rails replaced the singleton client without shutting down the previous instance, leaving old queues/timers/transports alive.
- The async queue's `length < max_queue_size` check and enqueue were not atomic under concurrent producer threads.
- `$feature_flag_called` dedupe state used a plain hash/array and bounded only distinct IDs, not per-distinct-id entries.
- Client/worker/transport shutdown was not idempotent or fully synchronized.
- Feature flag HTTP requests set `read_timeout` but not `open_timeout`/`write_timeout`, so boot or flag evaluation could block longer than intended on network issues.

Changes:

- Wrap worker error callbacks so callback exceptions are logged and do not crash the worker or leave an in-flight batch uncleared.
- Add explicit client and worker shutdown state, make client shutdown idempotent, stop accepting new events after shutdown, and join worker threads briefly during shutdown.
- Synchronize queue clear/enqueue operations so max queue size remains enforced with concurrent producers.
- Synchronize feature flag called-event dedupe and use a private bounded array for per-distinct-id dedupe keys.
- Synchronize `Transport` request/shutdown access around the persistent `Net::HTTP` instance and make shutdown idempotent.
- Apply open/read/write timeouts to feature flag `Net::HTTP.start` calls.
- Shut down the previous Rails singleton client when `PostHog.init` is called again, with an inline note explaining the replacement/shutdown behavior.
- Add regression tests for each fix and a patch changeset.

Review follow-up:

- Documented that `SendWorker#run` intentionally closes the persistent transport when a short-lived worker exits after draining the queue, and future bursts reconnect lazily.
- Scoped the new worker spec's transport stub to the worker under test instead of using `allow_any_instance_of`.
- Documented the intent of the concurrent queue regression test's widened check-then-push race window.

## :green_heart: How did you test it?

```bash
bundle exec rspec --format progress
```

Result: `526 examples, 0 failures`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to inspect the Ruby SDK/Rails integration, reproduce a worker flush hang caused by a raising `on_error` callback, implement targeted fixes, run the test suite, and address PR review feedback. During review, we kept the new bounded array private and chose separate shutdown state instead of overloading the disabled-client flag because disabled configuration and lifecycle shutdown have different semantics.
