### PR TITLE
fix(rails): define PostHog.init before app initializers

### DIFF
--- a/.changeset/early-rails-init.md
+++ b/.changeset/early-rails-init.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": patch
+---
+
+Fix Rails initializer load order so `PostHog.init` is available when `posthog-rails` is required.

--- a/posthog-rails/lib/posthog/rails.rb
+++ b/posthog-rails/lib/posthog/rails.rb
@@ -12,6 +12,7 @@ require 'posthog/rails/logs/severity'
 require 'posthog/rails/logs/rate_limiter'
 require 'posthog/rails/logs/appender'
 require 'posthog/rails/logs/setup'
+require 'posthog/rails/facade'
 require 'posthog/rails/railtie'
 
 module PostHog
@@ -63,3 +64,5 @@ module PostHog
     end
   end
 end
+
+PostHog::Rails.install_posthog_facade!

--- a/posthog-rails/lib/posthog/rails/facade.rb
+++ b/posthog-rails/lib/posthog/rails/facade.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module PostHog
+  module Rails
+    # Install the Rails singleton-style PostHog facade at load time so Rails app
+    # initializers can call PostHog.init before Railtie initializers run.
+    #
+    # @api private
+    # @return [void]
+    def self.install_posthog_facade!
+      return if @posthog_facade_installed
+
+      PostHog.class_eval do
+        class << self
+          attr_accessor :client
+
+          # Initialize the singleton PostHog client used by Rails delegators.
+          #
+          # @param options [Hash] Core {PostHog::Client} options.
+          # @yieldparam config [PostHog::Rails::InitConfig] Block-based core SDK configuration.
+          # @return [PostHog::Client]
+          def init(options = {})
+            # If block given, yield to configuration
+            if block_given?
+              config = PostHog::Rails::InitConfig.new(options)
+              yield config
+              options = config.to_client_options
+            end
+
+            # Let the PostHog Logs pipeline reuse the same api_key/host without
+            # the core client exposing public readers.
+            PostHog::Rails::Logs::Setup.remember_client_options(options) if defined?(PostHog::Rails::Logs::Setup)
+
+            # Create the PostHog client. If a client already exists, shut it down
+            # after replacement so repeated init calls do not leave background
+            # resources from the previous instance running.
+            previous_client = @client
+            @client = PostHog::Client.new(options)
+            begin
+              previous_client&.shutdown
+            rescue StandardError => e
+              PostHog::Logging.logger.warn("Failed to shut down previous PostHog client: #{e.message}")
+            end
+            @client
+          end
+
+          # @return [Boolean] Whether {PostHog.init} has created a client.
+          def initialized?
+            !@client.nil?
+          end
+
+          # Fallback for any client methods not explicitly defined.
+          #
+          # @api private
+          def method_missing(method_name, ...)
+            ensure_initialized!
+
+            if client.respond_to?(method_name)
+              client.public_send(method_name, ...)
+            else
+              super
+            end
+          end
+
+          # @api private
+          def respond_to_missing?(method_name, include_private = false)
+            ensure_initialized!
+            client.respond_to?(method_name, include_private) || super
+          end
+
+          private
+
+          def ensure_initialized!
+            return if initialized?
+
+            @client = PostHog::Client.new(api_key: nil, silence_disabled_client_error: true)
+          end
+        end
+      end
+
+      %i[
+        capture
+        capture_exception
+        identify
+        alias
+        group_identify
+        is_feature_enabled
+        get_feature_flag
+        get_all_flags
+      ].each do |method_name|
+        PostHog.define_singleton_method(method_name) do |*args, **kwargs, &block|
+          ensure_initialized!
+          client.public_send(method_name, *args, **kwargs, &block)
+        end
+      end
+
+      @posthog_facade_installed = true
+    end
+  end
+end

--- a/posthog-rails/lib/posthog/rails/railtie.rb
+++ b/posthog-rails/lib/posthog/rails/railtie.rb
@@ -1,97 +1,14 @@
 # frozen_string_literal: true
 
+require 'posthog/rails/facade'
+
 module PostHog
   module Rails
     class Railtie < ::Rails::Railtie
-      # Add PostHog module methods for accessing Rails-specific client
+      # Keep the historical Railtie initializer name, but install the facade at
+      # load time so application initializers can call PostHog.init.
       initializer 'posthog.set_configs' do |_app|
-        PostHog.class_eval do
-          class << self
-            attr_accessor :client
-
-            # Methods explicitly delegated to the client
-            DELEGATED_METHODS = %i[
-              capture
-              capture_exception
-              identify
-              alias
-              group_identify
-              is_feature_enabled
-              get_feature_flag
-              get_all_flags
-            ].freeze
-
-            # Initialize the singleton PostHog client used by Rails delegators.
-            #
-            # @param options [Hash] Core {PostHog::Client} options.
-            # @yieldparam config [PostHog::Rails::InitConfig] Block-based core SDK configuration.
-            # @return [PostHog::Client]
-            def init(options = {})
-              # If block given, yield to configuration
-              if block_given?
-                config = PostHog::Rails::InitConfig.new(options)
-                yield config
-                options = config.to_client_options
-              end
-
-              # Let the PostHog Logs pipeline reuse the same api_key/host without
-              # the core client exposing public readers.
-              PostHog::Rails::Logs::Setup.remember_client_options(options) if defined?(PostHog::Rails::Logs::Setup)
-
-              # Create the PostHog client. If a client already exists, shut it down
-              # after replacement so repeated init calls do not leave background
-              # resources from the previous instance running.
-              previous_client = @client
-              @client = PostHog::Client.new(options)
-              begin
-                previous_client&.shutdown
-              rescue StandardError => e
-                PostHog::Logging.logger.warn("Failed to shut down previous PostHog client: #{e.message}")
-              end
-              @client
-            end
-
-            # Define delegated methods using metaprogramming
-            DELEGATED_METHODS.each do |method_name|
-              define_method(method_name) do |*args, **kwargs, &block|
-                ensure_initialized!
-                client.public_send(method_name, *args, **kwargs, &block)
-              end
-            end
-
-            # @return [Boolean] Whether {PostHog.init} has created a client.
-            def initialized?
-              !@client.nil?
-            end
-
-            # Fallback for any client methods not explicitly defined.
-            #
-            # @api private
-            def method_missing(method_name, ...)
-              ensure_initialized!
-
-              if client.respond_to?(method_name)
-                client.public_send(method_name, ...)
-              else
-                super
-              end
-            end
-
-            # @api private
-            def respond_to_missing?(method_name, include_private = false)
-              ensure_initialized!
-              client.respond_to?(method_name, include_private) || super
-            end
-
-            private
-
-            def ensure_initialized!
-              return if initialized?
-
-              @client = PostHog::Client.new(api_key: nil, silence_disabled_client_error: true)
-            end
-          end
-        end
+        PostHog::Rails.install_posthog_facade!
       end
 
       # Insert middleware for request context and exception capturing

--- a/spec/posthog/rails/railtie_spec.rb
+++ b/spec/posthog/rails/railtie_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-# Minimal requires for testing the Railtie in isolation
+# Load the full Rails stack so the boot-order test can simulate real load order.
 require 'logger'
 require 'rails'
 

--- a/spec/posthog/rails/railtie_spec.rb
+++ b/spec/posthog/rails/railtie_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 # Minimal requires for testing the Railtie in isolation
 require 'logger'
-require 'posthog'
-require 'rails/railtie'
+require 'rails'
 
 # The posthog-rails lib has its own gemspec and isn't in the default load path,
 # so we add it manually for testing.
@@ -20,6 +21,17 @@ require 'posthog/rails/railtie'
 require 'posthog/rails'
 
 RSpec.describe PostHog::Rails::Railtie do
+  describe 'PostHog facade load order' do
+    after { PostHog.client = nil }
+
+    it 'allows PostHog.init before Railtie initializers run' do
+      client = PostHog.init(api_key: 'phc_test', test_mode: true)
+
+      expect(client).to be_a(PostHog::Client)
+      expect(PostHog.client).to eq(client)
+    end
+  end
+
   describe 'posthog.set_configs initializer' do
     before do
       initializer = PostHog::Rails::Railtie.initializers.find { |i| i.name == 'posthog.set_configs' }


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes #106.

Rails applications can run app initializers before the `posthog.set_configs` Railtie initializer. The generated `posthog-rails` initializer calls `PostHog.init`, but that method was previously defined inside the Railtie initializer, so some apps could boot with `NoMethodError: undefined method 'init' for module PostHog`.

This moves the Rails PostHog facade installation to load time so `PostHog.init` is available as soon as `posthog-rails` is required, while keeping the existing Railtie initializer as an idempotent compatibility hook.

## :green_heart: How did you test it?
- `bundle exec ruby -Ilib -Iposthog-rails/lib -e 'require "rails"; require "posthog-rails"; puts PostHog.respond_to?(:init)'`
- `bundle exec rspec spec/posthog/rails/railtie_spec.rb`
- `bundle exec rspec spec/posthog/rails`
- `bundle exec rspec spec/posthog/client_spec.rb spec/posthog/flags_spec.rb spec/posthog/rails`
- `bundle exec rake public_api:check`
- `bundle exec rubocop posthog-rails/lib/posthog/rails.rb posthog-rails/lib/posthog/rails/railtie.rb posthog-rails/lib/posthog/rails/facade.rb spec/posthog/rails/railtie_spec.rb`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi. The change keeps the existing Rails facade behavior but moves the method definitions into a small load-time helper so the generated Rails initializer can call `PostHog.init` before Railtie initializers have run. A targeted regression test covers that `PostHog.init` can create the client on the pre-Railtie path.
