### PR TITLE
feat(rails): add current user resolver

### DIFF
--- a/.changeset/current-user-resolver.md
+++ b/.changeset/current-user-resolver.md
@@ -1,0 +1,5 @@
+---
+'posthog-rails': minor
+---
+
+Add Rails current user resolver configuration for exception capture.

--- a/posthog-rails/README.md
+++ b/posthog-rails/README.md
@@ -9,20 +9,6 @@ SDK usage examples and code snippets live in the official documentation so they 
 - [Ruby on Rails framework docs](https://posthog.com/docs/libraries/ruby-on-rails)
 - [Ruby library docs](https://posthog.com/docs/libraries/ruby)
 
-## User context for exception capture
-
-By default, exception capture calls `current_user` on the controller. Apps that
-use `ActiveSupport::CurrentAttributes` can provide a resolver instead:
-
-```ruby
-PostHog::Rails.configure do |config|
-  config.current_user_resolver = proc { Current.user }
-end
-```
-
-The resolver takes precedence over `current_user_method` and may accept the
-controller as an argument.
-
 ## PostHog Logs (optional)
 
 `posthog-rails` can forward `Rails.logger` output to [PostHog Logs](https://posthog.com/docs/logs)

--- a/posthog-rails/README.md
+++ b/posthog-rails/README.md
@@ -9,6 +9,20 @@ SDK usage examples and code snippets live in the official documentation so they 
 - [Ruby on Rails framework docs](https://posthog.com/docs/libraries/ruby-on-rails)
 - [Ruby library docs](https://posthog.com/docs/libraries/ruby)
 
+## User context for exception capture
+
+By default, exception capture calls `current_user` on the controller. Apps that
+use `ActiveSupport::CurrentAttributes` can provide a resolver instead:
+
+```ruby
+PostHog::Rails.configure do |config|
+  config.current_user_resolver = proc { Current.user }
+end
+```
+
+The resolver takes precedence over `current_user_method` and may accept the
+controller as an argument.
+
 ## PostHog Logs (optional)
 
 `posthog-rails` can forward `Rails.logger` output to [PostHog Logs](https://posthog.com/docs/logs)

--- a/posthog-rails/examples/posthog.rb
+++ b/posthog-rails/examples/posthog.rb
@@ -37,6 +37,12 @@ PostHog::Rails.configure do |config|
   # making it easier to identify affected users and debug user-specific issues.
   # config.current_user_method = :current_user
 
+  # Or provide a resolver for apps that store user context outside controllers,
+  # such as ActiveSupport::CurrentAttributes. The resolver takes precedence over
+  # current_user_method and may accept the controller as an argument.
+  # config.current_user_resolver = proc { Current.user }
+  # config.current_user_resolver = proc { |controller| controller.current_user }
+
   # Additional exception classes to exclude from reporting
   # These are added to the default excluded exceptions
   # config.excluded_exceptions = [

--- a/posthog-rails/lib/generators/posthog/templates/posthog.rb
+++ b/posthog-rails/lib/generators/posthog/templates/posthog.rb
@@ -37,6 +37,12 @@ PostHog::Rails.configure do |config|
   # making it easier to identify affected users and debug user-specific issues.
   # config.current_user_method = :current_user
 
+  # Or provide a resolver for apps that store user context outside controllers,
+  # such as ActiveSupport::CurrentAttributes. The resolver takes precedence over
+  # current_user_method and may accept the controller as an argument.
+  # config.current_user_resolver = proc { Current.user }
+  # config.current_user_resolver = proc { |controller| controller.current_user }
+
   # Additional exception classes to exclude from reporting
   # These are added to the default excluded exceptions
   # config.excluded_exceptions = [

--- a/posthog-rails/lib/posthog/rails/capture_exceptions.rb
+++ b/posthog-rails/lib/posthog/rails/capture_exceptions.rb
@@ -89,10 +89,11 @@ module PostHog
       end
 
       def call_current_user_resolver(resolver, controller)
-        return controller.instance_exec(&resolver) if resolver.arity.zero? && controller
-        return resolver.call if resolver.arity.zero?
-
-        resolver.call(controller)
+        if resolver.arity.zero?
+          controller ? controller.instance_exec(&resolver) : resolver.call
+        elsif controller
+          resolver.call(controller)
+        end
       end
 
       def extract_user_id(user)

--- a/posthog-rails/lib/posthog/rails/capture_exceptions.rb
+++ b/posthog-rails/lib/posthog/rails/capture_exceptions.rb
@@ -69,18 +69,30 @@ module PostHog
       def extract_distinct_id(env)
         # Prefer authenticated Rails user context. Request/tracing context is
         # applied later by the core capture path if this returns nil.
-        if PostHog::Rails.config&.capture_user_context && env['action_controller.instance']
-          controller = env['action_controller.instance']
-          method_name = PostHog::Rails.config&.current_user_method || :current_user
+        return nil unless PostHog::Rails.config&.capture_user_context
 
-          if controller.respond_to?(method_name, true)
-            user = controller.send(method_name)
-            user_id = extract_user_id(user) if user
-            return user_id if present?(user_id)
-          end
-        end
+        user = extract_current_user(env['action_controller.instance'])
+        user_id = extract_user_id(user) if user
+        return user_id if present?(user_id)
 
         nil
+      end
+
+      def extract_current_user(controller)
+        resolver = PostHog::Rails.config&.current_user_resolver
+        return call_current_user_resolver(resolver, controller) if resolver
+
+        method_name = PostHog::Rails.config&.current_user_method || :current_user
+        return unless controller.respond_to?(method_name, true)
+
+        controller.send(method_name)
+      end
+
+      def call_current_user_resolver(resolver, controller)
+        return controller.instance_exec(&resolver) if resolver.arity.zero? && controller
+        return resolver.call if resolver.arity.zero?
+
+        resolver.call(controller)
       end
 
       def extract_user_id(user)

--- a/posthog-rails/lib/posthog/rails/capture_exceptions.rb
+++ b/posthog-rails/lib/posthog/rails/capture_exceptions.rb
@@ -80,12 +80,19 @@ module PostHog
 
       def extract_current_user(controller)
         resolver = PostHog::Rails.config&.current_user_resolver
-        return call_current_user_resolver(resolver, controller) if resolver
+        return resolve_current_user(resolver, controller) if resolver
 
         method_name = PostHog::Rails.config&.current_user_method || :current_user
         return unless controller.respond_to?(method_name, true)
 
         controller.send(method_name)
+      end
+
+      def resolve_current_user(resolver, controller)
+        call_current_user_resolver(resolver, controller)
+      rescue StandardError => e
+        PostHog::Logging.logger.warn("current_user_resolver failed: #{e.message}")
+        nil
       end
 
       def call_current_user_resolver(resolver, controller)

--- a/posthog-rails/lib/posthog/rails/configuration.rb
+++ b/posthog-rails/lib/posthog/rails/configuration.rb
@@ -32,6 +32,10 @@ module PostHog
       # @return [Symbol] Method name to call on controller to get the current user. Defaults to :current_user.
       attr_accessor :current_user_method
 
+      # @return [Proc, nil] Callable used to resolve the current user. When set, this takes precedence over
+      #   current_user_method. The callable may accept the controller instance or no arguments.
+      attr_accessor :current_user_resolver
+
       # @return [Symbol, nil] Method name to call on the user object to get distinct_id. When nil, tries:
       #   posthog_distinct_id, distinct_id, id, pk, uuid in order.
       attr_accessor :user_id_method
@@ -68,6 +72,7 @@ module PostHog
         @use_tracing_headers = true
         @capture_user_context = true
         @current_user_method = :current_user
+        @current_user_resolver = nil
         @user_id_method = nil
         @logs_enabled = false
         @logs_forward_rails_logger = true

--- a/spec/posthog/rails/configuration_spec.rb
+++ b/spec/posthog/rails/configuration_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe PostHog::Rails::Configuration do
     end
   end
 
+  describe 'user context defaults' do
+    it 'defaults to controller current_user without a resolver' do
+      expect(config.current_user_method).to eq(:current_user)
+      expect(config.current_user_resolver).to be_nil
+    end
+  end
+
   describe 'PostHog Logs defaults' do
     it 'defaults logs to disabled with forwarding ready' do
       expect(config.logs_enabled).to be false

--- a/spec/posthog/rails/request_context_spec.rb
+++ b/spec/posthog/rails/request_context_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe PostHog::Rails::RequestContext do
     expect(message[:properties]['$session_id']).to eq('exception-session')
   end
 
-  it 'uses a configured current_user_resolver for exceptions' do
+  it 'supports current_user_resolver variants for exceptions' do
     PostHog::Rails.config.auto_capture_exceptions = true
 
     current_class = Class.new do
@@ -237,35 +237,6 @@ RSpec.describe PostHog::Rails::RequestContext do
     end
     stub_const('Current', current_class)
     Current.user = Struct.new(:id).new('current-user')
-    PostHog::Rails.config.current_user_resolver = proc { Current.user }
-
-    allow(PostHog).to receive(:capture_exception) do |exception, distinct_id, properties|
-      client.capture_exception(exception, distinct_id, properties)
-    end
-
-    app = lambda do |_env|
-      raise StandardError, 'boom'
-    end
-    middleware = described_class.new(PostHog::Rails::CaptureExceptions.new(app))
-
-    expect do
-      middleware.call(
-        env_for(
-          '/boom',
-          'HTTP_X_POSTHOG_DISTINCT_ID' => 'header-user',
-          'HTTP_X_POSTHOG_SESSION_ID' => 'exception-session'
-        )
-      )
-    end.to raise_error(StandardError, 'boom')
-
-    message = client.dequeue_last_message
-    expect(message[:event]).to eq('$exception')
-    expect(message[:distinct_id]).to eq('current-user')
-    expect(message[:properties]['$session_id']).to eq('exception-session')
-  end
-
-  it 'passes the controller to a current_user_resolver that accepts an argument' do
-    PostHog::Rails.config.auto_capture_exceptions = true
 
     user = Struct.new(:id).new('resolved-user')
     controller_class = Class.new do
@@ -283,24 +254,54 @@ RSpec.describe PostHog::Rails::RequestContext do
         'show'
       end
     end
-    PostHog::Rails.config.current_user_resolver = proc(&:posthog_user)
 
     allow(PostHog).to receive(:capture_exception) do |exception, distinct_id, properties|
       client.capture_exception(exception, distinct_id, properties)
     end
 
-    app = lambda do |env|
-      env['action_controller.instance'] = controller_class.new(user)
-      raise StandardError, 'boom'
+    [
+      {
+        description: 'without arguments',
+        resolver: proc { Current.user },
+        controller: nil,
+        expected_distinct_id: 'current-user'
+      },
+      {
+        description: 'with a controller argument',
+        resolver: proc(&:posthog_user),
+        controller: controller_class.new(user),
+        expected_distinct_id: 'resolved-user'
+      },
+      {
+        description: 'with a controller argument but no controller',
+        resolver: proc(&:posthog_user),
+        controller: nil,
+        expected_distinct_id: 'header-user'
+      }
+    ].each do |scenario|
+      PostHog::Rails.config.current_user_resolver = scenario.fetch(:resolver)
+
+      app = lambda do |env|
+        env['action_controller.instance'] = scenario[:controller] if scenario[:controller]
+        raise StandardError, "boom #{scenario.fetch(:description)}"
+      end
+      middleware = described_class.new(PostHog::Rails::CaptureExceptions.new(app))
+
+      expect do
+        middleware.call(
+          env_for(
+            '/boom',
+            'HTTP_X_POSTHOG_DISTINCT_ID' => 'header-user',
+            'HTTP_X_POSTHOG_SESSION_ID' => 'exception-session'
+          )
+        )
+      end.to raise_error(StandardError, "boom #{scenario.fetch(:description)}")
+
+      message = client.dequeue_last_message
+      expect(message[:event]).to eq('$exception')
+      expect(message[:distinct_id]).to eq(scenario.fetch(:expected_distinct_id))
+      expect(message[:properties]['$session_id']).to eq('exception-session')
     end
-    middleware = described_class.new(PostHog::Rails::CaptureExceptions.new(app))
-
-    expect do
-      middleware.call(env_for('/boom'))
-    end.to raise_error(StandardError, 'boom')
-
-    message = client.dequeue_last_message
-    expect(message[:distinct_id]).to eq('resolved-user')
   end
 
   it 'captures exceptions with tracing context and re-raises' do

--- a/spec/posthog/rails/request_context_spec.rb
+++ b/spec/posthog/rails/request_context_spec.rb
@@ -277,6 +277,12 @@ RSpec.describe PostHog::Rails::RequestContext do
         resolver: proc(&:posthog_user),
         controller: nil,
         expected_distinct_id: 'header-user'
+      },
+      {
+        description: 'when the resolver raises',
+        resolver: proc { raise 'resolver failed' },
+        controller: nil,
+        expected_distinct_id: 'header-user'
       }
     ].each do |scenario|
       PostHog::Rails.config.current_user_resolver = scenario.fetch(:resolver)

--- a/spec/posthog/rails/request_context_spec.rb
+++ b/spec/posthog/rails/request_context_spec.rb
@@ -227,6 +227,82 @@ RSpec.describe PostHog::Rails::RequestContext do
     expect(message[:properties]['$session_id']).to eq('exception-session')
   end
 
+  it 'uses a configured current_user_resolver for exceptions' do
+    PostHog::Rails.config.auto_capture_exceptions = true
+
+    current_class = Class.new do
+      class << self
+        attr_accessor :user
+      end
+    end
+    stub_const('Current', current_class)
+    Current.user = Struct.new(:id).new('current-user')
+    PostHog::Rails.config.current_user_resolver = proc { Current.user }
+
+    allow(PostHog).to receive(:capture_exception) do |exception, distinct_id, properties|
+      client.capture_exception(exception, distinct_id, properties)
+    end
+
+    app = lambda do |_env|
+      raise StandardError, 'boom'
+    end
+    middleware = described_class.new(PostHog::Rails::CaptureExceptions.new(app))
+
+    expect do
+      middleware.call(
+        env_for(
+          '/boom',
+          'HTTP_X_POSTHOG_DISTINCT_ID' => 'header-user',
+          'HTTP_X_POSTHOG_SESSION_ID' => 'exception-session'
+        )
+      )
+    end.to raise_error(StandardError, 'boom')
+
+    message = client.dequeue_last_message
+    expect(message[:event]).to eq('$exception')
+    expect(message[:distinct_id]).to eq('current-user')
+    expect(message[:properties]['$session_id']).to eq('exception-session')
+  end
+
+  it 'passes the controller to a current_user_resolver that accepts an argument' do
+    PostHog::Rails.config.auto_capture_exceptions = true
+
+    user = Struct.new(:id).new('resolved-user')
+    controller_class = Class.new do
+      attr_reader :posthog_user
+
+      def initialize(user)
+        @posthog_user = user
+      end
+
+      def controller_name
+        'posts'
+      end
+
+      def action_name
+        'show'
+      end
+    end
+    PostHog::Rails.config.current_user_resolver = proc(&:posthog_user)
+
+    allow(PostHog).to receive(:capture_exception) do |exception, distinct_id, properties|
+      client.capture_exception(exception, distinct_id, properties)
+    end
+
+    app = lambda do |env|
+      env['action_controller.instance'] = controller_class.new(user)
+      raise StandardError, 'boom'
+    end
+    middleware = described_class.new(PostHog::Rails::CaptureExceptions.new(app))
+
+    expect do
+      middleware.call(env_for('/boom'))
+    end.to raise_error(StandardError, 'boom')
+
+    message = client.dequeue_last_message
+    expect(message[:distinct_id]).to eq('resolved-user')
+  end
+
   it 'captures exceptions with tracing context and re-raises' do
     PostHog::Rails.config.auto_capture_exceptions = true
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Closes #102.

Rails apps that use `ActiveSupport::CurrentAttributes` (for example, `Current.user`) currently need to define a controller method solely for PostHog exception user context. This adds a resolver hook so apps can provide the current user directly while keeping the existing `current_user_method` behavior.

## :green_heart: How did you test it?

- `BUNDLE_PATH=../posthog-ruby/vendor/bundle bundle exec rspec spec/posthog/rails/request_context_spec.rb spec/posthog/rails/configuration_spec.rb`
- `BUNDLE_PATH=../posthog-ruby/vendor/bundle bundle exec rubocop posthog-rails/lib/posthog/rails/capture_exceptions.rb spec/posthog/rails/request_context_spec.rb`
- `BUNDLE_PATH=../posthog-ruby/vendor/bundle bundle exec rake public_api:check`
- `BUNDLE_PATH=../posthog-ruby/vendor/bundle bundle exec rspec`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi coding agent. The change adds `PostHog::Rails.config.current_user_resolver`, which takes precedence over `current_user_method` and supports both no-argument resolvers like `proc { Current.user }` and controller-aware resolvers. Existing controller method behavior is preserved for backwards compatibility. Controller-aware resolvers safely no-op when an exception occurs before Rails has instantiated a controller, and resolver failures fall back to request/tracing context instead of dropping exception capture.
