### PR TITLE
fix: prevent test mode shutdown hangs

### DIFF
--- a/.changeset/quiet-owls-flush.md
+++ b/.changeset/quiet-owls-flush.md
@@ -1,0 +1,5 @@
+---
+'posthog-ruby': patch
+---
+
+Make flush and shutdown safe for test mode clients with queued events.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -165,6 +165,11 @@ module PostHog
         return
       end
 
+      if @worker.is_a?(NoopWorker)
+        clear
+        return
+      end
+
       while !@queue.empty? || @worker.is_requesting?
         ensure_worker_running
         sleep(0.1)

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1462,6 +1462,20 @@ module PostHog
           Process.wait
         end
       end
+
+      it 'clears NoopWorker queues without hanging' do
+        test_client = Client.new(api_key: API_KEY, test_mode: true)
+        test_client.capture(Queued::CAPTURE)
+
+        thread = Thread.new { test_client.flush }
+        begin
+          expect(thread.join(1)).to eq(thread)
+          thread.value
+        ensure
+          thread.kill if thread.alive?
+        end
+        expect(test_client.queued_messages).to eq(0)
+      end
     end
 
     describe '#shutdown' do
@@ -1473,6 +1487,20 @@ module PostHog
 
         expect(worker).to have_received(:shutdown).once
         expect(client.capture(Queued::CAPTURE)).to eq(false)
+      end
+
+      it 'does not hang with a queued test mode event' do
+        test_client = Client.new(api_key: API_KEY, test_mode: true)
+        test_client.capture(Queued::CAPTURE)
+
+        thread = Thread.new { test_client.shutdown }
+        begin
+          expect(thread.join(1)).to eq(thread)
+          thread.value
+        ensure
+          thread.kill if thread.alive?
+        end
+        expect(test_client.queued_messages).to eq(0)
       end
     end
 

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1462,20 +1462,6 @@ module PostHog
           Process.wait
         end
       end
-
-      it 'clears NoopWorker queues without hanging' do
-        test_client = Client.new(api_key: API_KEY, test_mode: true)
-        test_client.capture(Queued::CAPTURE)
-
-        thread = Thread.new { test_client.flush }
-        begin
-          expect(thread.join(1)).to eq(thread)
-          thread.value
-        ensure
-          thread.kill if thread.alive?
-        end
-        expect(test_client.queued_messages).to eq(0)
-      end
     end
 
     describe '#shutdown' do
@@ -1488,19 +1474,23 @@ module PostHog
         expect(worker).to have_received(:shutdown).once
         expect(client.capture(Queued::CAPTURE)).to eq(false)
       end
+    end
 
-      it 'does not hang with a queued test mode event' do
-        test_client = Client.new(api_key: API_KEY, test_mode: true)
-        test_client.capture(Queued::CAPTURE)
+    %i[flush shutdown].each do |method|
+      describe "##{method} with NoopWorker" do
+        it 'clears queued test mode events without hanging' do
+          test_client = Client.new(api_key: API_KEY, test_mode: true)
+          test_client.capture(Queued::CAPTURE)
 
-        thread = Thread.new { test_client.shutdown }
-        begin
-          expect(thread.join(1)).to eq(thread)
-          thread.value
-        ensure
-          thread.kill if thread.alive?
+          thread = Thread.new { test_client.public_send(method) }
+          begin
+            expect(thread.join(1)).to eq(thread)
+            thread.value
+          ensure
+            thread.kill if thread.alive?
+          end
+          expect(test_client.queued_messages).to eq(0)
         end
-        expect(test_client.queued_messages).to eq(0)
       end
     end
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes #111.

In test mode, the client uses `NoopWorker`, which intentionally does not drain queued events. If an event is queued before `flush` or Rails' `at_exit` shutdown path runs, the existing drain loop can wait forever.

This change makes `flush` clear and return when the client is using `NoopWorker`, which also makes `shutdown` safe for test-mode clients.

## :green_heart: How did you test it?

- `BUNDLE_PATH=/Users/marandaneto/Github/posthog-ruby/vendor/bundle bundle exec rspec spec/posthog/client_spec.rb`
- `BUNDLE_PATH=/Users/marandaneto/Github/posthog-ruby/vendor/bundle bundle exec rubocop lib/posthog/client.rb spec/posthog/client_spec.rb`
- Manual timeout checks for queued test-mode `flush` and `shutdown`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A coding agent investigated the open issue, reproduced the test-mode hang locally, and implemented the smallest fix: detect `NoopWorker` in `flush`, clear the queue, and return. Regression specs use a parameterized case to cover both direct `flush` and `shutdown`, since Rails calls shutdown from `at_exit`.
