### PR TITLE
fix(rails): handle missing middleware insertion targets

### DIFF
--- a/.changeset/rails-middleware-fallback.md
+++ b/.changeset/rails-middleware-fallback.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": patch
+---
+
+Handle missing Rails middleware insertion targets with safe fallbacks.

--- a/posthog-rails/lib/posthog/rails/railtie.rb
+++ b/posthog-rails/lib/posthog/rails/railtie.rb
@@ -147,23 +147,88 @@ module PostHog
         end
       end
 
+      MISSING_MIDDLEWARE_MESSAGE = 'No such middleware to insert'
+
       # @api private
       # @return [void]
       def insert_middleware_after(app, target, middleware)
-        # During initialization, app.config.middleware is a MiddlewareStackProxy
-        # which only supports recording operations (insert_after, use, etc.)
-        # and does NOT support query methods like include?.
-        app.config.middleware.insert_after(target, middleware)
+        insert_middleware(app.config.middleware, :after, target, middleware)
       end
 
       # @api private
       # @return [void]
       def insert_middleware_before(app, target, middleware)
-        # During initialization, app.config.middleware is a MiddlewareStackProxy
-        # which only supports recording operations (insert_before, use, etc.)
-        # and does NOT support query methods like include?.
-        app.config.middleware.insert_before(target, middleware)
+        insert_middleware(app.config.middleware, :before, target, middleware)
       end
+
+      # During initialization, app.config.middleware is usually a
+      # Rails::Configuration::MiddlewareStackProxy. The proxy only records
+      # operations, so missing-target errors happen later when Rails builds the
+      # real ActionDispatch::MiddlewareStack. Add our own deferred operation so
+      # we can fall back at build time instead of crashing or silently skipping.
+      def insert_middleware(middleware_stack, location, target, middleware)
+        if middleware_stack_proxy?(middleware_stack)
+          append_middleware_operation(middleware_stack) do |resolved_stack|
+            insert_middleware_with_fallback(resolved_stack, location, target, middleware)
+          end
+        else
+          insert_middleware_with_fallback(middleware_stack, location, target, middleware)
+        end
+      end
+
+      def middleware_stack_proxy?(middleware_stack)
+        defined?(::Rails::Configuration::MiddlewareStackProxy) &&
+          middleware_stack.instance_of?(::Rails::Configuration::MiddlewareStackProxy) &&
+          middleware_stack.instance_variable_defined?(:@operations)
+      end
+
+      def append_middleware_operation(middleware_stack, &operation)
+        middleware_stack.instance_variable_get(:@operations) << operation
+      end
+
+      def insert_middleware_with_fallback(middleware_stack, location, target, middleware)
+        perform_middleware_insert(middleware_stack, location, target, middleware)
+      rescue RuntimeError => e
+        raise unless missing_middleware_error?(e)
+
+        fallback_insert_middleware(middleware_stack, location, target, middleware)
+      end
+
+      def perform_middleware_insert(middleware_stack, location, target, middleware)
+        if location == :after
+          middleware_stack.insert_after(target, middleware)
+        else
+          middleware_stack.insert_before(target, middleware)
+        end
+      end
+
+      def fallback_insert_middleware(middleware_stack, location, target, middleware)
+        fallback_position = if location == :before && middleware_stack.respond_to?(:unshift)
+                              middleware_stack.unshift(middleware)
+                              'beginning'
+                            else
+                              middleware_stack.use(middleware)
+                              'end'
+                            end
+
+        PostHog::Logging.logger.warn(
+          "Could not find #{target.inspect} in the Rails middleware stack; " \
+          "inserted #{middleware.inspect} at the #{fallback_position} " \
+          'of the stack instead.'
+        )
+      end
+
+      def missing_middleware_error?(error)
+        error.message.start_with?(MISSING_MIDDLEWARE_MESSAGE)
+      end
+
+      private :insert_middleware,
+              :middleware_stack_proxy?,
+              :append_middleware_operation,
+              :insert_middleware_with_fallback,
+              :perform_middleware_insert,
+              :fallback_insert_middleware,
+              :missing_middleware_error?
 
       # Build the PostHog Logs pipeline and broadcast Rails.logger into it.
       #

--- a/posthog-rails/lib/posthog/rails/railtie.rb
+++ b/posthog-rails/lib/posthog/rails/railtie.rb
@@ -160,7 +160,13 @@ module PostHog
             middleware
           )
         end
+
+        private :posthog_insert_middleware_with_fallback
       end
+
+      private_constant :MISSING_MIDDLEWARE_MESSAGE,
+                       :MIDDLEWARE_FALLBACK_OPERATION,
+                       :MiddlewareStackFallback
 
       # @api private
       # @return [void]
@@ -196,7 +202,7 @@ module PostHog
       def append_middleware_operation(middleware_stack, location, target, middleware)
         operations = middleware_stack.instance_variable_get(:@operations)
 
-        if callable_middleware_operations?(operations)
+        if callable_middleware_operations?(middleware_stack, operations)
           operations << lambda do |resolved_stack|
             insert_middleware_with_fallback(resolved_stack, location, target, middleware)
           end
@@ -206,10 +212,16 @@ module PostHog
         end
       end
 
-      def callable_middleware_operations?(operations)
-        return ::Rails::VERSION::MAJOR >= 7 if operations.empty?
+      def callable_middleware_operations?(middleware_stack, operations)
+        operation = operations.first || probe_middleware_operation(middleware_stack)
 
-        operations.all? { |operation| operation.respond_to?(:call) }
+        operation.respond_to?(:call)
+      end
+
+      def probe_middleware_operation(middleware_stack)
+        probe = middleware_stack.class.new
+        probe.use(Object)
+        probe.instance_variable_get(:@operations).first
       end
 
       def ensure_middleware_stack_fallback_operation!
@@ -259,6 +271,7 @@ module PostHog
               :middleware_stack_proxy?,
               :append_middleware_operation,
               :callable_middleware_operations?,
+              :probe_middleware_operation,
               :ensure_middleware_stack_fallback_operation!,
               :insert_middleware_with_fallback,
               :perform_middleware_insert,

--- a/posthog-rails/lib/posthog/rails/railtie.rb
+++ b/posthog-rails/lib/posthog/rails/railtie.rb
@@ -148,6 +148,19 @@ module PostHog
       end
 
       MISSING_MIDDLEWARE_MESSAGE = 'No such middleware to insert'
+      MIDDLEWARE_FALLBACK_OPERATION = :posthog_insert_middleware_with_fallback
+
+      module MiddlewareStackFallback
+        def posthog_insert_middleware_with_fallback(location, target, middleware)
+          PostHog::Rails::Railtie.instance.send(
+            :insert_middleware_with_fallback,
+            self,
+            location,
+            target,
+            middleware
+          )
+        end
+      end
 
       # @api private
       # @return [void]
@@ -168,9 +181,7 @@ module PostHog
       # we can fall back at build time instead of crashing or silently skipping.
       def insert_middleware(middleware_stack, location, target, middleware)
         if middleware_stack_proxy?(middleware_stack)
-          append_middleware_operation(middleware_stack) do |resolved_stack|
-            insert_middleware_with_fallback(resolved_stack, location, target, middleware)
-          end
+          append_middleware_operation(middleware_stack, location, target, middleware)
         else
           insert_middleware_with_fallback(middleware_stack, location, target, middleware)
         end
@@ -182,8 +193,30 @@ module PostHog
           middleware_stack.instance_variable_defined?(:@operations)
       end
 
-      def append_middleware_operation(middleware_stack, &operation)
-        middleware_stack.instance_variable_get(:@operations) << operation
+      def append_middleware_operation(middleware_stack, location, target, middleware)
+        operations = middleware_stack.instance_variable_get(:@operations)
+
+        if callable_middleware_operations?(operations)
+          operations << lambda do |resolved_stack|
+            insert_middleware_with_fallback(resolved_stack, location, target, middleware)
+          end
+        else
+          ensure_middleware_stack_fallback_operation!
+          operations << [MIDDLEWARE_FALLBACK_OPERATION, [location, target, middleware], nil]
+        end
+      end
+
+      def callable_middleware_operations?(operations)
+        return ::Rails::VERSION::MAJOR >= 7 if operations.empty?
+
+        operations.all? { |operation| operation.respond_to?(:call) }
+      end
+
+      def ensure_middleware_stack_fallback_operation!
+        require 'action_dispatch/middleware/stack' unless defined?(::ActionDispatch::MiddlewareStack)
+        return if ::ActionDispatch::MiddlewareStack < MiddlewareStackFallback
+
+        ::ActionDispatch::MiddlewareStack.include(MiddlewareStackFallback)
       end
 
       def insert_middleware_with_fallback(middleware_stack, location, target, middleware)
@@ -225,6 +258,8 @@ module PostHog
       private :insert_middleware,
               :middleware_stack_proxy?,
               :append_middleware_operation,
+              :callable_middleware_operations?,
+              :ensure_middleware_stack_fallback_operation!,
               :insert_middleware_with_fallback,
               :perform_middleware_insert,
               :fallback_insert_middleware,

--- a/spec/posthog/rails/railtie_spec.rb
+++ b/spec/posthog/rails/railtie_spec.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 # Minimal requires for testing the Railtie in isolation
 require 'logger'
 require 'posthog'
+require 'rails'
 require 'rails/railtie'
+require 'action_dispatch/middleware/stack'
 
 # The posthog-rails lib has its own gemspec and isn't in the default load path,
 # so we add it manually for testing.
@@ -72,7 +76,7 @@ RSpec.describe PostHog::Rails::Railtie do
       expect(railtie).to respond_to(:insert_middleware_before)
     end
 
-    it 'successfully calls insert_middleware_after when the initializer runs' do
+    it 'successfully records middleware operations when the initializer runs' do
       # Stub the middleware constants referenced in the initializer block
       stub_const('ActionDispatch::DebugExceptions', Class.new)
       stub_const('ActionDispatch::ShowExceptions', Class.new)
@@ -84,10 +88,7 @@ RSpec.describe PostHog::Rails::Railtie do
       initializer = PostHog::Rails::Railtie.initializers.find { |i| i.name == 'posthog.insert_middlewares' }
       expect(initializer).not_to be_nil
 
-      # During initialization, app.config.middleware is a MiddlewareStackProxy
-      # which only supports recording operations — NOT query methods like include?.
-      # The mock must reflect this accurately.
-      middleware_proxy = double('MiddlewareStackProxy', insert_after: true, insert_before: true)
+      middleware_proxy = Rails::Configuration::MiddlewareStackProxy.new
       app = double('app', config: double('config', middleware: middleware_proxy))
 
       # Reproduce the exact execution context: the block is run via instance_exec
@@ -97,6 +98,74 @@ RSpec.describe PostHog::Rails::Railtie do
       expect do
         railtie.instance_exec(app, &initializer.block)
       end.not_to raise_error
+    end
+
+    it 'inserts middleware before and after the target when it is present' do
+      stub_const('TargetMiddleware', Class.new)
+      stub_const('BeforeMiddleware', Class.new)
+      stub_const('AfterMiddleware', Class.new)
+
+      middleware_proxy = Rails::Configuration::MiddlewareStackProxy.new
+      app = double('app', config: double('config', middleware: middleware_proxy))
+      railtie = PostHog::Rails::Railtie.instance
+
+      railtie.insert_middleware_before(app, TargetMiddleware, BeforeMiddleware)
+      railtie.insert_middleware_after(app, TargetMiddleware, AfterMiddleware)
+
+      stack = ActionDispatch::MiddlewareStack.new
+      stack.use(TargetMiddleware)
+      middleware_proxy.merge_into(stack)
+
+      expected_middlewares = [
+        BeforeMiddleware,
+        TargetMiddleware,
+        AfterMiddleware
+      ]
+      expect(stack.middlewares.map(&:klass)).to eq(expected_middlewares)
+    end
+
+    it 'falls back to appending middleware when the deferred after target is missing' do
+      stub_const('MissingTargetMiddleware', Class.new)
+      stub_const('FallbackMiddleware', Class.new)
+
+      logger = instance_spy(Logger)
+      PostHog::Logging.logger = logger
+      middleware_proxy = Rails::Configuration::MiddlewareStackProxy.new
+      app = double('app', config: double('config', middleware: middleware_proxy))
+
+      PostHog::Rails::Railtie.instance.insert_middleware_after(
+        app,
+        MissingTargetMiddleware,
+        FallbackMiddleware
+      )
+
+      stack = ActionDispatch::MiddlewareStack.new
+      expect { middleware_proxy.merge_into(stack) }.not_to raise_error
+      expect(stack.middlewares.map(&:klass)).to eq([FallbackMiddleware])
+      expect(logger).to have_received(:warn).with(/Could not find MissingTargetMiddleware/)
+    end
+
+    it 'falls back to prepending middleware when the deferred before target is missing' do
+      stub_const('MissingTargetMiddleware', Class.new)
+      stub_const('ExistingMiddleware', Class.new)
+      stub_const('FallbackMiddleware', Class.new)
+
+      logger = instance_spy(Logger)
+      PostHog::Logging.logger = logger
+      middleware_proxy = Rails::Configuration::MiddlewareStackProxy.new
+      app = double('app', config: double('config', middleware: middleware_proxy))
+
+      PostHog::Rails::Railtie.instance.insert_middleware_before(
+        app,
+        MissingTargetMiddleware,
+        FallbackMiddleware
+      )
+
+      stack = ActionDispatch::MiddlewareStack.new
+      stack.use(ExistingMiddleware)
+      expect { middleware_proxy.merge_into(stack) }.not_to raise_error
+      expect(stack.middlewares.map(&:klass)).to eq([FallbackMiddleware, ExistingMiddleware])
+      expect(logger).to have_received(:warn).with(/Could not find MissingTargetMiddleware/)
     end
   end
 

--- a/spec/posthog/rails/railtie_spec.rb
+++ b/spec/posthog/rails/railtie_spec.rb
@@ -185,8 +185,9 @@ RSpec.describe PostHog::Rails::Railtie do
       expect(legacy_block).to be_nil
 
       stack = ActionDispatch::MiddlewareStack.new
-      stack.public_send(legacy_operation, *legacy_args, &legacy_block)
+      stack.send(legacy_operation, *legacy_args, &legacy_block)
 
+      expect(stack).not_to respond_to(:posthog_insert_middleware_with_fallback)
       expect(stack.middlewares.map(&:klass)).to eq([FallbackMiddleware])
       expect(logger).to have_received(:warn).with(/Could not find MissingTargetMiddleware/)
     end

--- a/spec/posthog/rails/railtie_spec.rb
+++ b/spec/posthog/rails/railtie_spec.rb
@@ -124,13 +124,53 @@ RSpec.describe PostHog::Rails::Railtie do
       expect(stack.middlewares.map(&:klass)).to eq(expected_middlewares)
     end
 
-    it 'falls back to appending middleware when the deferred after target is missing' do
+    [
+      {
+        location: :after,
+        existing_middlewares: [],
+        expected_middlewares: %w[FallbackMiddleware]
+      },
+      {
+        location: :before,
+        existing_middlewares: %w[ExistingMiddleware],
+        expected_middlewares: %w[FallbackMiddleware ExistingMiddleware]
+      }
+    ].each do |scenario|
+      it "falls back when the deferred #{scenario[:location]} target is missing" do
+        stub_const('MissingTargetMiddleware', Class.new)
+        stub_const('ExistingMiddleware', Class.new)
+        stub_const('FallbackMiddleware', Class.new)
+
+        logger = instance_spy(Logger)
+        PostHog::Logging.logger = logger
+        middleware_proxy = Rails::Configuration::MiddlewareStackProxy.new
+        app = double('app', config: double('config', middleware: middleware_proxy))
+
+        PostHog::Rails::Railtie.instance.public_send(
+          "insert_middleware_#{scenario[:location]}",
+          app,
+          MissingTargetMiddleware,
+          FallbackMiddleware
+        )
+
+        stack = ActionDispatch::MiddlewareStack.new
+        scenario[:existing_middlewares].each { |middleware| stack.use(Object.const_get(middleware)) }
+        expected_middlewares = scenario[:expected_middlewares].map { |middleware| Object.const_get(middleware) }
+
+        expect { middleware_proxy.merge_into(stack) }.not_to raise_error
+        expect(stack.middlewares.map(&:klass)).to eq(expected_middlewares)
+        expect(logger).to have_received(:warn).with(/Could not find MissingTargetMiddleware/)
+      end
+    end
+
+    it 'records legacy middleware proxy operations with Rails 5/6 tuple format' do
       stub_const('MissingTargetMiddleware', Class.new)
       stub_const('FallbackMiddleware', Class.new)
 
       logger = instance_spy(Logger)
       PostHog::Logging.logger = logger
       middleware_proxy = Rails::Configuration::MiddlewareStackProxy.new
+      middleware_proxy.instance_variable_set(:@operations, [[:use, [], nil]])
       app = double('app', config: double('config', middleware: middleware_proxy))
 
       PostHog::Rails::Railtie.instance.insert_middleware_after(
@@ -139,32 +179,15 @@ RSpec.describe PostHog::Rails::Railtie do
         FallbackMiddleware
       )
 
+      legacy_operation, legacy_args, legacy_block = middleware_proxy.instance_variable_get(:@operations).last
+      expect(legacy_operation).to eq(:posthog_insert_middleware_with_fallback)
+      expect(legacy_args).to eq([:after, MissingTargetMiddleware, FallbackMiddleware])
+      expect(legacy_block).to be_nil
+
       stack = ActionDispatch::MiddlewareStack.new
-      expect { middleware_proxy.merge_into(stack) }.not_to raise_error
+      stack.public_send(legacy_operation, *legacy_args, &legacy_block)
+
       expect(stack.middlewares.map(&:klass)).to eq([FallbackMiddleware])
-      expect(logger).to have_received(:warn).with(/Could not find MissingTargetMiddleware/)
-    end
-
-    it 'falls back to prepending middleware when the deferred before target is missing' do
-      stub_const('MissingTargetMiddleware', Class.new)
-      stub_const('ExistingMiddleware', Class.new)
-      stub_const('FallbackMiddleware', Class.new)
-
-      logger = instance_spy(Logger)
-      PostHog::Logging.logger = logger
-      middleware_proxy = Rails::Configuration::MiddlewareStackProxy.new
-      app = double('app', config: double('config', middleware: middleware_proxy))
-
-      PostHog::Rails::Railtie.instance.insert_middleware_before(
-        app,
-        MissingTargetMiddleware,
-        FallbackMiddleware
-      )
-
-      stack = ActionDispatch::MiddlewareStack.new
-      stack.use(ExistingMiddleware)
-      expect { middleware_proxy.merge_into(stack) }.not_to raise_error
-      expect(stack.middlewares.map(&:klass)).to eq([FallbackMiddleware, ExistingMiddleware])
       expect(logger).to have_received(:warn).with(/Could not find MissingTargetMiddleware/)
     end
   end


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #99.

Rails applications can customize their middleware stack so `ActionDispatch::ShowExceptions` or `ActionDispatch::DebugExceptions` may be absent. The Railtie previously recorded direct `insert_before` / `insert_after` calls, which could fail later when Rails built the real middleware stack.

This change records fallback-aware middleware operations for Rails' deferred middleware proxy. If the target middleware is missing, PostHog still inserts its middleware and logs a warning instead of failing or silently skipping it.

## :green_heart: How did you test it?

- `BUNDLE_PATH=/Users/marandaneto/Github/posthog-ruby/vendor/bundle bundle exec rubocop posthog-rails/lib/posthog/rails/railtie.rb spec/posthog/rails/railtie_spec.rb`
- `BUNDLE_PATH=/Users/marandaneto/Github/posthog-ruby/vendor/bundle bundle exec rspec spec/posthog/rails`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi in a dedicated worktree. The fix keeps the existing Railtie API but replaces direct deferred middleware proxy calls with fallback-aware operations, so normal insertion order is preserved when targets exist and safe insertion is used when targets are absent.
