### PR TITLE
fix: Normalize ignored batch metadata fields

### DIFF
--- a/.changeset/quiet-badgers-notice.md
+++ b/.changeset/quiet-badgers-notice.md
@@ -2,4 +2,4 @@
 'posthog-ruby': patch
 ---
 
-Document deprecated top-level batch metadata fields and canonical replacements.
+Stop sending ignored top-level batch metadata fields and normalize deprecated message IDs to event UUIDs.

--- a/.changeset/quiet-badgers-notice.md
+++ b/.changeset/quiet-badgers-notice.md
@@ -2,4 +2,4 @@
 'posthog-ruby': patch
 ---
 
-Stop sending ignored top-level batch metadata fields and normalize deprecated message IDs to event UUIDs.
+Stop sending ignored top-level batch metadata fields and always send event UUIDs, normalizing deprecated message IDs when valid.

--- a/.changeset/quiet-badgers-notice.md
+++ b/.changeset/quiet-badgers-notice.md
@@ -1,0 +1,5 @@
+---
+'posthog-ruby': patch
+---
+
+Document deprecated top-level batch metadata fields and canonical replacements.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -181,9 +181,9 @@ module PostHog
     end
 
     # @!macro common_attrs
-    #   @option attrs [String] :message_id Deprecated no-op. The batch endpoint ignores `messageId`.
-    #     Use `:uuid` on capture events for event identity/deduplication instead. Read SDK metadata from
-    #     `$lib` and `$lib_version` properties, not top-level `library` / `library_version` fields.
+    #   @option attrs [String] :message_id Deprecated. Use `:uuid` instead. If `:uuid` is absent and
+    #     `:message_id` is a valid UUID, it is sent as `uuid` for backwards compatibility.
+    #     SDK metadata is sent as `$lib` and `$lib_version` properties.
     #   @option attrs [Time] :timestamp When the event occurred (optional)
     #   @option attrs [String] :distinct_id The ID for this user in your database
 
@@ -949,10 +949,6 @@ module PostHog
 
       action = process_before_send(action)
       return false if action.nil? || action.empty?
-
-      # Deprecated top-level request id retained for backwards compatibility.
-      # PostHog ingestion ignores `messageId`; use `uuid` on capture events for event identity/deduplication.
-      action[:messageId] ||= uid
 
       if @sync_mode
         send_sync(action)

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -181,9 +181,10 @@ module PostHog
     end
 
     # @!macro common_attrs
-    #   @option attrs [String] :message_id Deprecated. Use `:uuid` instead. If `:uuid` is absent and
-    #     `:message_id` is a valid UUID, it is sent as `uuid` for backwards compatibility.
-    #     SDK metadata is sent as `$lib` and `$lib_version` properties.
+    #   @option attrs [String] :message_id Deprecated. Use `:uuid` instead. If `:uuid` is absent or
+    #     invalid and `:message_id` is a valid UUID, it is sent as `uuid` for backwards compatibility.
+    #     If neither value is valid, the SDK generates a `uuid`. SDK metadata is sent as `$lib` and
+    #     `$lib_version` properties.
     #   @option attrs [Time] :timestamp When the event occurred (optional)
     #   @option attrs [String] :distinct_id The ID for this user in your database
 

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -181,8 +181,9 @@ module PostHog
     end
 
     # @!macro common_attrs
-    #   @option attrs [String] :message_id ID that uniquely
-    #     identifies a message across the API. (optional)
+    #   @option attrs [String] :message_id Deprecated no-op. The batch endpoint ignores `messageId`.
+    #     Use `:uuid` on capture events for event identity/deduplication instead. Read SDK metadata from
+    #     `$lib` and `$lib_version` properties, not top-level `library` / `library_version` fields.
     #   @option attrs [Time] :timestamp When the event occurred (optional)
     #   @option attrs [String] :distinct_id The ID for this user in your database
 
@@ -949,7 +950,8 @@ module PostHog
       action = process_before_send(action)
       return false if action.nil? || action.empty?
 
-      # add our request id for tracing purposes
+      # Deprecated top-level request id retained for backwards compatibility.
+      # PostHog ingestion ignores `messageId`; use `uuid` on capture events for event identity/deduplication.
       action[:messageId] ||= uid
 
       if @sync_mode

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+
 require 'posthog/logging'
 
 module PostHog
@@ -129,6 +131,8 @@ module PostHog
       # - "distinct_id"
       # - "message_id" (deprecated; normalized to "uuid" when it is a valid UUID)
       # - "send_feature_flags"
+      #
+      # A new "uuid" is generated when neither "uuid" nor "message_id" is valid.
       def parse_common_fields(fields)
         timestamp = fields[:timestamp] || Time.new
         distinct_id = fields[:distinct_id]
@@ -151,8 +155,7 @@ module PostHog
           properties: properties
         }
 
-        uuid = normalized_uuid(fields)
-        parsed['uuid'] = uuid if uuid
+        parsed['uuid'] = normalized_uuid(fields)
 
         if send_feature_flags && fields[:feature_variants]
           feature_variants = fields[:feature_variants]
@@ -193,7 +196,7 @@ module PostHog
         message_id = fields[:message_id]
         return message_id if message_id && valid_uuid_for_event_props?(message_id)
 
-        nil
+        SecureRandom.uuid
       end
 
       # @param [Object] uuid - the UUID to validate, user provided, so we don't know the type

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -151,8 +151,8 @@ module PostHog
           properties: properties
         }
 
-        uuid = fields[:uuid] || fields[:message_id]
-        parsed['uuid'] = uuid if uuid && valid_uuid_for_event_props?(uuid)
+        uuid = normalized_uuid(fields)
+        parsed['uuid'] = uuid if uuid
 
         if send_feature_flags && fields[:feature_variants]
           feature_variants = fields[:feature_variants]
@@ -184,6 +184,16 @@ module PostHog
 
       def check_is_hash!(obj, name)
         raise ArgumentError, "#{name} must be a Hash" unless obj.is_a? Hash
+      end
+
+      def normalized_uuid(fields)
+        uuid = fields[:uuid]
+        return uuid if uuid && valid_uuid_for_event_props?(uuid)
+
+        message_id = fields[:message_id]
+        return message_id if message_id && valid_uuid_for_event_props?(message_id)
+
+        nil
       end
 
       # @param [Object] uuid - the UUID to validate, user provided, so we don't know the type

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -25,7 +25,6 @@ module PostHog
         event = fields[:event]
         properties = fields[:properties] || {}
         groups = fields[:groups]
-        uuid = fields[:uuid]
         check_presence!(event, 'event')
         check_is_hash!(properties, 'properties')
 
@@ -35,8 +34,6 @@ module PostHog
         end
 
         isoify_dates! properties
-
-        common['uuid'] = uuid if valid_uuid_for_event_props? uuid
 
         common.merge(
           {
@@ -130,12 +127,11 @@ module PostHog
       #
       # - "timestamp"
       # - "distinct_id"
-      # - "message_id" (deprecated no-op; use "uuid" on capture events for event identity/deduplication)
+      # - "message_id" (deprecated; normalized to "uuid" when it is a valid UUID)
       # - "send_feature_flags"
       def parse_common_fields(fields)
         timestamp = fields[:timestamp] || Time.new
         distinct_id = fields[:distinct_id]
-        message_id = fields[:message_id].to_s if fields[:message_id]
         send_feature_flags = fields[:send_feature_flags]
 
         check_timestamp! timestamp
@@ -149,17 +145,14 @@ module PostHog
         }
         properties['$is_server'] = true if is_server
 
-        # Deprecated top-level metadata retained for backwards compatibility.
-        # PostHog ingestion reads SDK metadata from `$lib` / `$lib_version` properties
-        # and event identity from `uuid`, not from `library`, `library_version`, or `messageId`.
         parsed = {
           timestamp: datetime_in_iso8601(timestamp),
-          library: 'posthog-ruby',
-          library_version: PostHog::VERSION.to_s,
-          messageId: message_id,
           distinct_id: distinct_id,
           properties: properties
         }
+
+        uuid = fields[:uuid] || fields[:message_id]
+        parsed['uuid'] = uuid if uuid && valid_uuid_for_event_props?(uuid)
 
         if send_feature_flags && fields[:feature_variants]
           feature_variants = fields[:feature_variants]

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -130,7 +130,7 @@ module PostHog
       #
       # - "timestamp"
       # - "distinct_id"
-      # - "message_id"
+      # - "message_id" (deprecated no-op; use "uuid" on capture events for event identity/deduplication)
       # - "send_feature_flags"
       def parse_common_fields(fields)
         timestamp = fields[:timestamp] || Time.new
@@ -149,6 +149,9 @@ module PostHog
         }
         properties['$is_server'] = true if is_server
 
+        # Deprecated top-level metadata retained for backwards compatibility.
+        # PostHog ingestion reads SDK metadata from `$lib` / `$lib_version` properties
+        # and event identity from `uuid`, not from `library`, `library_version`, or `messageId`.
         parsed = {
           timestamp: datetime_in_iso8601(timestamp),
           library: 'posthog-ruby',

--- a/lib/posthog/utils.rb
+++ b/lib/posthog/utils.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'securerandom'
-
 module PostHog
   class InconclusiveMatchError < StandardError
   end
@@ -58,16 +56,6 @@ module PostHog
     #
     def isoify_dates!(hash)
       hash.replace isoify_dates hash
-    end
-
-    # public: Returns a uid string
-    #
-    def uid
-      arr = SecureRandom.random_bytes(16).unpack('NnnnnN')
-      arr[2] = (arr[2] & 0x0fff) | 0x4000
-      arr[3] = (arr[3] & 0x3fff) | 0x8000
-
-      '%08x-%04x-%04x-%04x-%04x%08x' % arr # rubocop:disable Style/FormatStringToken, Style/FormatString
     end
 
     def datetime_in_iso8601(datetime)

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -744,6 +744,39 @@ module PostHog
         expect(logger).not_to have_received(:warn)
       end
 
+      it 'falls back to a valid message_id when uuid is invalid' do
+        client.capture(
+          {
+            distinct_id: 'distinct_id',
+            event: 'test_event',
+            uuid: 'i am obviously not a uuid',
+            message_id: '123e4567-e89b-12d3-a456-426614174000'
+          }
+        )
+
+        message = client.dequeue_last_message
+        expect(message['uuid']).to eq('123e4567-e89b-12d3-a456-426614174000')
+        expect(logger).to have_received(:warn).with(
+          'UUID is not valid: i am obviously not a uuid. Ignoring it.'
+        )
+      end
+
+      it 'does not use invalid message_id as uuid' do
+        client.capture(
+          {
+            distinct_id: 'distinct_id',
+            event: 'test_event',
+            message_id: 'i am also not a uuid'
+          }
+        )
+
+        message = client.dequeue_last_message
+        expect(message).not_to have_key('uuid')
+        expect(logger).to have_received(:warn).with(
+          'UUID is not valid: i am also not a uuid. Ignoring it.'
+        )
+      end
+
       it 'does not require a uuid be provided - ingestion will generate when absent' do
         allow(logger).to receive(:warn)
 

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1713,8 +1713,6 @@ module PostHog
     end
 
     context 'common' do
-      check_property = proc { |msg, k, v| msg[k] && msg[k] == v }
-
       let(:data) do
         { distinct_id: 1, alias: 3, message_id: 5, event: 'cockatoo' }
       end
@@ -1755,10 +1753,16 @@ module PostHog
         expect(queue.length).to eq(1)
       end
 
-      it 'converts message id to string' do
+      it 'keeps deprecated top-level metadata while sending canonical properties' do
         %i[capture identify alias].each do |s|
           client.send(s, data)
-          expect(check_property.call(client.dequeue_last_message, :messageId, '5')).to eq(true)
+          message = client.dequeue_last_message
+
+          expect(message[:messageId]).to eq('5')
+          expect(message[:library]).to eq('posthog-ruby')
+          expect(message[:library_version]).to eq(PostHog::VERSION.to_s)
+          expect(message[:properties]['$lib']).to eq('posthog-ruby')
+          expect(message[:properties]['$lib_version']).to eq(PostHog::VERSION.to_s)
         end
       end
     end

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1717,13 +1717,12 @@ module PostHog
         { distinct_id: 1, alias: 3, message_id: 5, event: 'cockatoo' }
       end
 
-      it 'returns false if queue is full' do
-        client.instance_variable_set(:@max_queue_size, 1)
+      %i[capture identify alias].each do |method_name|
+        it "returns false for #{method_name} if queue is full" do
+          client.instance_variable_set(:@max_queue_size, 1)
 
-        %i[capture identify alias].each do |s|
-          expect(client.send(s, data)).to eq(true)
-          expect(client.send(s, data)).to eq(false) # Queue is full
-          client.clear
+          expect(client.send(method_name, data)).to eq(true)
+          expect(client.send(method_name, data)).to eq(false) # Queue is full
         end
       end
 
@@ -1753,9 +1752,9 @@ module PostHog
         expect(queue.length).to eq(1)
       end
 
-      it 'keeps deprecated top-level metadata while sending canonical properties' do
-        %i[capture identify alias].each do |s|
-          client.send(s, data)
+      %i[capture identify alias].each do |method_name|
+        it "keeps deprecated top-level metadata while sending canonical properties for #{method_name}" do
+          client.send(method_name, data)
           message = client.dequeue_last_message
 
           expect(message[:messageId]).to eq('5')

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -761,7 +761,7 @@ module PostHog
         )
       end
 
-      it 'does not use invalid message_id as uuid' do
+      it 'generates a uuid when message_id is invalid' do
         client.capture(
           {
             distinct_id: 'distinct_id',
@@ -771,13 +771,13 @@ module PostHog
         )
 
         message = client.dequeue_last_message
-        expect(message).not_to have_key('uuid')
+        expect(message['uuid']).to match(/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i)
         expect(logger).to have_received(:warn).with(
           'UUID is not valid: i am also not a uuid. Ignoring it.'
         )
       end
 
-      it 'does not require a uuid be provided - ingestion will generate when absent' do
+      it 'generates a uuid when uuid is absent' do
         allow(logger).to receive(:warn)
 
         client.capture(
@@ -786,13 +786,13 @@ module PostHog
             event: 'test_event'
           }
         )
-        properties = client.dequeue_last_message[:properties]
-        # ingestion will add a UUID if one is not provided
-        expect(properties['uuid']).to be_nil
+
+        message = client.dequeue_last_message
+        expect(message['uuid']).to match(/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i)
         expect(logger).not_to have_received(:warn)
       end
 
-      it 'does not use invalid uuid' do
+      it 'generates a uuid when provided uuid is invalid' do
         client.capture(
           {
             distinct_id: 'distinct_id',
@@ -800,8 +800,9 @@ module PostHog
             uuid: 'i am obviously not a uuid'
           }
         )
-        properties = client.dequeue_last_message[:properties]
-        expect(properties['uuid']).to be_nil
+
+        message = client.dequeue_last_message
+        expect(message['uuid']).to match(/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i)
         expect(logger).to have_received(:warn).with(
           'UUID is not valid: i am obviously not a uuid. Ignoring it.'
         )
@@ -1057,7 +1058,7 @@ module PostHog
         # Verify the server was called because only_evaluate_locally was false
         assert_requested :post, flags_endpoint, times: 1
       end
-      it 'does not use really invalid uuid' do
+      it 'generates a uuid when provided uuid is not a string' do
         client.capture(
           {
             distinct_id: 'distinct_id',
@@ -1065,8 +1066,9 @@ module PostHog
             uuid: { 'not a uuid' => 'not a uuid' }
           }
         )
-        properties = client.dequeue_last_message[:properties]
-        expect(properties['uuid']).to be_nil
+
+        message = client.dequeue_last_message
+        expect(message['uuid']).to match(/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i)
         expect(logger).to have_received(:warn).with(
           'UUID is not a string. Ignoring it.'
         )

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1713,8 +1713,10 @@ module PostHog
     end
 
     context 'common' do
+      let(:message_id) { '123e4567-e89b-12d3-a456-426614174000' }
+
       let(:data) do
-        { distinct_id: 1, alias: 3, message_id: 5, event: 'cockatoo' }
+        { distinct_id: 1, alias: 3, message_id: message_id, event: 'cockatoo' }
       end
 
       %i[capture identify alias].each do |method_name|
@@ -1753,13 +1755,14 @@ module PostHog
       end
 
       %i[capture identify alias].each do |method_name|
-        it "keeps deprecated top-level metadata while sending canonical properties for #{method_name}" do
+        it "normalizes deprecated metadata into canonical fields for #{method_name}" do
           client.send(method_name, data)
           message = client.dequeue_last_message
 
-          expect(message[:messageId]).to eq('5')
-          expect(message[:library]).to eq('posthog-ruby')
-          expect(message[:library_version]).to eq(PostHog::VERSION.to_s)
+          expect(message).not_to have_key(:messageId)
+          expect(message).not_to have_key(:library)
+          expect(message).not_to have_key(:library_version)
+          expect(message['uuid']).to eq(message_id)
           expect(message[:properties]['$lib']).to eq('posthog-ruby')
           expect(message[:properties]['$lib_version']).to eq(PostHog::VERSION.to_s)
         end


### PR DESCRIPTION
## :bulb: Motivation and Context

Ruby batch payloads included top-level `library`, `library_version`, and `messageId` fields, but the batch ingestion path ignores those fields. Ingestion reads SDK metadata from event properties (`$lib`, `$lib_version`) and event identity from `uuid`.

This PR stops sending the ignored top-level fields while preserving the canonical metadata properties. Deprecated `message_id` input is normalized to `uuid` when it is a valid UUID and `uuid` is not otherwise provided. If neither `uuid` nor `message_id` is valid, the SDK now generates a UUID before enqueueing the event.

## :green_heart: How did you test it?

- `bundle exec rspec spec/posthog/client_spec.rb`
- `bundle exec rspec`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An AI coding agent cross-checked the Ruby payload against the PostHog batch ingestion path, then updated the SDK to stop emitting ignored top-level metadata fields. The PR keeps SDK metadata in the canonical `$lib` / `$lib_version` properties, normalizes deprecated `message_id` to event `uuid` when possible, and generates a fresh UUID when neither provided value is valid.

Review feedback was addressed by splitting looped assertions into separately named examples per SDK action, removing the now-orphaned `Utils#uid`, and making UUID normalization fall back from an invalid `uuid` to a valid `message_id` while still warning for invalid values. A patch changeset was added for the release note.
