### PR TITLE
fix: keep changelog notices out of release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,6 +318,7 @@ jobs:
           if [ -f "$CHANGELOG_FILE" ]; then
             awk -v defText="See $CHANGELOG_FILE" '
               /^## / { if (found_version) exit; found_version=1; next }
+              /^> Historical entries before the changelog split are copied from/ { next }
               found_version { print }
               END { if (!found_version) print defText }
             ' "$CHANGELOG_FILE" | sed '/[^[:space:]]/,$!d' | tac | sed '/[^[:space:]]/,$!d' | tac > release-notes.md


### PR DESCRIPTION
## :bulb: Motivation and Context

The package changelog notices about historical pre-split entries can appear inside the latest generated release section. Because GitHub release notes are extracted from that latest changelog section, the notice also appeared in the `posthog-ruby-v3.14.1` and `posthog-rails-v3.14.1` release notes.

This keeps the changelog content as-is, but prevents the historical notice from being included in future GitHub release notes.

## :green_heart: How did you test it?

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'workflow yaml ok'"`
- Verified the release note extraction skips the historical notice and only emits the latest release changes.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi. The fix leaves the changelog layout unchanged and updates the release workflow extraction logic to skip the historical package notice when creating GitHub release notes.
