### PR TITLE
fix: Clear feature flag called cache on shutdown

### DIFF
--- a/.changeset/quiet-cycles-shutdown.md
+++ b/.changeset/quiet-cycles-shutdown.md
@@ -1,5 +1,6 @@
 ---
 "posthog-ruby": patch
+"posthog-rails": patch
 ---
 
 Clear the feature flag call dedupe cache on shutdown.

--- a/.changeset/quiet-cycles-shutdown.md
+++ b/.changeset/quiet-cycles-shutdown.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": patch
+---
+
+Clear the feature flag call dedupe cache on shutdown.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -790,6 +790,9 @@ module PostHog
         @worker&.shutdown
         @worker_thread&.join(1)
       end
+      @distinct_id_has_sent_flag_calls_mutex.synchronize do
+        @distinct_id_has_sent_flag_calls.clear
+      end
     end
 
     private

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1534,6 +1534,14 @@ module PostHog
     end
 
     describe '#shutdown' do
+      it 'clears feature flag call dedupe cache' do
+        client.instance_variable_get(:@distinct_id_has_sent_flag_calls)['user'] = ['flag_true']
+
+        client.shutdown
+
+        expect(client.instance_variable_get(:@distinct_id_has_sent_flag_calls).length).to eq(0)
+      end
+
       it 'is idempotent and stops accepting new events' do
         worker = instance_spy(PostHog::NoopWorker, is_requesting?: false)
         client.instance_variable_set(:@worker, worker)


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feature flag call deduplication state currently remains in memory after `shutdown`, which can leak stale called-cache state across a client shutdown/reuse lifecycle. This clears the cache during shutdown while holding the existing cache mutex.

## :green_heart: How did you test it?

- [x] `bundle exec rspec spec/posthog/client_spec.rb`
- [x] `git diff --check`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. (Not needed.)
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a changeset file (`.changeset/quiet-cycles-shutdown.md`)

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An agent prepared this PR from the dedicated `fix/ff-called-cache-shutdown` worktree at the user's direction. The change adds a guarded shutdown-time clear of the feature flag call dedupe cache, a regression spec for that behavior, and a patch changeset for `posthog-ruby`.

Validation included the client spec file and whitespace checks. A local `pnpm changeset status --since=main` validation attempt failed because dependencies are not installed in this worktree (`changeset` executable missing), but the changeset file was added using the repository's Changesets format.
