### PR TITLE
feat(rails): stamp telemetry.sdk.name on forwarded logs

### DIFF
--- a/.changeset/ruby-logs-telemetry-sdk-name.md
+++ b/.changeset/ruby-logs-telemetry-sdk-name.md
@@ -1,0 +1,5 @@
+---
+"posthog-rails": patch
+---
+
+Stamp `telemetry.sdk.name = "posthog-ruby"` on forwarded logs so PostHog can attribute log volume to the Ruby SDK. Previously these records carried the OpenTelemetry SDK default (`opentelemetry`), so they could not be split out per-SDK the way the mobile SDKs are.

--- a/posthog-rails/lib/posthog/rails/logs/setup.rb
+++ b/posthog-rails/lib/posthog/rails/logs/setup.rb
@@ -184,6 +184,11 @@ module PostHog
             # The posthog-rails name/version travel with each record via the
             # instrumentation scope (see LoggerProvider#logger above).
             {
+              # Identifies these records as the PostHog Ruby SDK so PostHog's usage
+              # report can attribute log volume to Ruby (mirrors posthog-ios/android/
+              # flutter/react-native). Overrides the OpenTelemetry SDK default of
+              # 'opentelemetry'; the posthog-rails integration name stays on the scope.
+              'telemetry.sdk.name' => 'posthog-ruby',
               'service.name' => service_name,
               'deployment.environment' => ::Rails.env.to_s
             }

--- a/spec/posthog/rails/logs/setup_spec.rb
+++ b/spec/posthog/rails/logs/setup_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe PostHog::Rails::Logs::Setup do
 
     context 'when the OpenTelemetry gems are available' do
       let(:exporter_args) { {} }
+      let(:resource_attrs) { {} }
       let(:otel_logger) { double('otel_logger') }
       let(:provider) { double('provider', add_log_record_processor: nil, logger: otel_logger) }
 
@@ -82,8 +83,12 @@ RSpec.describe PostHog::Rails::Logs::Setup do
         resource_class.define_singleton_method(:create) { |attrs| attrs }
 
         provider_double = provider
+        captured_resource = resource_attrs
         provider_class = Class.new
-        provider_class.define_singleton_method(:new) { |**| provider_double }
+        provider_class.define_singleton_method(:new) do |**kwargs|
+          captured_resource.merge!(kwargs[:resource] || {})
+          provider_double
+        end
 
         captured = exporter_args
         exporter_class = Class.new
@@ -109,6 +114,14 @@ RSpec.describe PostHog::Rails::Logs::Setup do
         expect(appender).to be_a(PostHog::Rails::Logs::Appender)
         expect(exporter_args[:endpoint]).to eq('https://us.i.posthog.com/i/v1/logs')
         expect(exporter_args[:headers]).to eq('Authorization' => 'Bearer phc_token')
+      end
+
+      it 'stamps telemetry.sdk.name so PostHog attributes the records to the Ruby SDK' do
+        described_class.remember_client_options(api_key: 'phc_token', host: 'https://us.i.posthog.com')
+
+        described_class.install
+
+        expect(resource_attrs['telemetry.sdk.name']).to eq('posthog-ruby')
       end
 
       it 'supports string-keyed init options and strips a trailing slash from the host' do


### PR DESCRIPTION
## Problem

posthog-rails forwards `Rails.logger` output to PostHog Logs over OTLP, but the records carry the OpenTelemetry SDK's **default** resource attribute `telemetry.sdk.name = "opentelemetry"` (the gem never overrides it). PostHog's usage report splits per-SDK log volume by matching `telemetry.sdk.name` against the known PostHog SDKs (`posthog-ios`, `posthog-react-native`, `posthog-android`, `posthog-flutter`), so **Ruby logs match nothing and can't be attributed** — there is no `ruby_logs_records_in_period`.

## Change

Stamp `telemetry.sdk.name = "posthog-ruby"` on the OTLP resource, mirroring the convention the mobile SDKs already use.
