### PR TITLE
ci: clarify workflow failure checks

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -9,9 +9,12 @@ on:
 
 jobs:
     call-flags-project:
+        # Dependabot and forked PRs cannot access the app credentials required by
+        # the reusable project-board workflow.
+        if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        secrets: inherit
+        secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit -- reusable workflow requires inherited secrets

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -7,6 +7,8 @@ on:
     pull_request:
         types: [opened, ready_for_review, review_requested, synchronize, converted_to_draft, reopened]
 
+permissions: {}
+
 jobs:
     call-flags-project:
         # Dependabot and forked PRs cannot access the app credentials required by

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,6 +55,19 @@ jobs:
       - name: Run RuboCop
         run: bundle exec rubocop
 
+  public-api-snapshot:
+    name: Public API snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Use Ruby 3.4
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
+        with:
+          ruby-version: 3.4
+          bundler: 4.0.13
+          bundler-cache: true
+
       - name: Check public API snapshot
         run: bundle exec rake public_api:check
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Two CI issues were still valid after investigation:

- The feature flags project-board workflow fails for Dependabot/fork-style PR contexts because project-board app credentials are unavailable there.
- The public API snapshot check runs inside the `RuboCop` job, so API snapshot failures are reported as RuboCop failures even when RuboCop passes.

This updates the workflows so those failures are clearer and avoids running the project-board integration when the needed credentials cannot be present. The reusable project-board workflow still uses `secrets: inherit`; it does not currently declare named `workflow_call` secrets, so this PR documents and suppresses that Semgrep finding inline like the equivalent posthog-js fix. The caller workflow also explicitly disables default `GITHUB_TOKEN` permissions because it only uses the app token created by the reusable workflow.

## :green_heart: How did you test it?

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts "parsed #{f}" }'`
- `bundle exec rake public_api:check`
- `bundle exec rubocop`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A coding agent investigated recent GitHub Actions runs, confirmed the Dependabot credential failure and the hidden public API snapshot failure mode, then made focused workflow-only changes to address both findings. The project-board workflow is skipped for Dependabot and fork PRs because those contexts cannot receive the project-board app credentials; `secrets: inherit` is kept because the pinned reusable workflow expects inherited secrets. The public API check now has its own clearly named job.
