### PR TITLE
fix: Preserve exception stack frame paths

### DIFF
--- a/.changeset/relative-exception-filenames.md
+++ b/.changeset/relative-exception-filenames.md
@@ -1,5 +1,6 @@
 ---
 'posthog-ruby': patch
+'posthog-rails': patch
 ---
 
 Preserve relative paths in captured exception stack frame filenames.

--- a/.changeset/relative-exception-filenames.md
+++ b/.changeset/relative-exception-filenames.md
@@ -1,0 +1,5 @@
+---
+'posthog-ruby': patch
+---
+
+Preserve relative paths in captured exception stack frame filenames.

--- a/lib/posthog/exception_capture.rb
+++ b/lib/posthog/exception_capture.rb
@@ -72,18 +72,69 @@ module PostHog
       lineno = match[2].to_i
       method_name = match[5]
 
+      in_app = !gem_path?(file)
+
       frame = {
-        'filename' => File.basename(file),
+        'filename' => compute_filename(file, in_app),
         'abs_path' => file,
         'lineno' => lineno,
         'function' => method_name,
-        'in_app' => !gem_path?(file),
+        'in_app' => in_app,
         'platform' => 'ruby'
       }
 
       add_context_lines(frame, file, lineno) if frame['in_app'] && File.exist?(file)
 
       frame
+    end
+
+    # @param path [String]
+    # @param in_app [Boolean]
+    # @return [String]
+    def self.compute_filename(path, in_app)
+      return path unless absolute_path?(path)
+
+      prefixes = in_app ? [rails_root, Dir.pwd] : $LOAD_PATH
+      strip_path_prefix(path, prefixes) || path
+    end
+
+    # @param path [String]
+    # @param prefixes [Array<String, nil>]
+    # @return [String, nil]
+    def self.strip_path_prefix(path, prefixes)
+      normalized_path = normalize_path(path)
+      normalized_prefixes = prefixes.compact.map do |prefix|
+        normalize_path(File.expand_path(prefix.to_s))
+      end
+
+      normalized_prefixes
+        .select { |prefix| normalized_path.start_with?("#{prefix}/") }
+        .max_by(&:length)
+        &.then { |prefix| normalized_path[(prefix.length + 1)..] }
+    end
+
+    # @param path [String]
+    # @return [String]
+    def self.normalize_path(path)
+      path.tr('\\', '/').sub(%r{/+\z}, '')
+    end
+
+    # @return [String, nil]
+    def self.rails_root
+      return nil unless Object.const_defined?(:Rails)
+
+      rails = Object.const_get(:Rails)
+      return nil unless rails.respond_to?(:root) && rails.root
+
+      rails.root.to_s
+    rescue StandardError
+      nil
+    end
+
+    # @param path [String]
+    # @return [Boolean]
+    def self.absolute_path?(path)
+      path.start_with?('/') || path.match?(%r{\A[a-zA-Z]:[/\\]})
     end
 
     # @param path [String]

--- a/lib/posthog/exception_capture.rb
+++ b/lib/posthog/exception_capture.rb
@@ -116,7 +116,10 @@ module PostHog
     # @param path [String]
     # @return [String]
     def self.normalize_path(path)
-      path.tr('\\', '/').sub(%r{/+\z}, '')
+      normalized = path.tr('\\', '/')
+      end_index = normalized.length
+      end_index -= 1 while end_index.positive? && normalized.getbyte(end_index - 1) == 47
+      normalized[0...end_index]
     end
 
     # @return [String, nil]
@@ -124,9 +127,12 @@ module PostHog
       return nil unless Object.const_defined?(:Rails)
 
       rails = Object.const_get(:Rails)
-      return nil unless rails.respond_to?(:root) && rails.root
+      return nil unless rails.respond_to?(:root)
 
-      rails.root.to_s
+      root = rails.root
+      return nil unless root
+
+      root.to_s
     rescue StandardError
       nil
     end

--- a/spec/posthog/exception_capture_spec.rb
+++ b/spec/posthog/exception_capture_spec.rb
@@ -2,21 +2,45 @@
 
 require 'spec_helper'
 
-# rubocop:disable Layout/LineLength
-
 module PostHog
   describe ExceptionCapture do
     describe '#parse_backtrace_line' do
       it 'parses stacktrace line into frame with correct details' do
-        line = '/path/to/project/app/models/user.rb:42:in `validate_email\''
+        path = File.join(Dir.pwd, 'app/models/user.rb')
+        line = "#{path}:42:in `validate_email'"
         frame = described_class.parse_backtrace_line(line)
 
-        expect(frame['filename']).to eq('user.rb')
-        expect(frame['abs_path']).to eq('/path/to/project/app/models/user.rb')
+        expect(frame['filename']).to eq('app/models/user.rb')
+        expect(frame['abs_path']).to eq(path)
         expect(frame['lineno']).to eq(42)
         expect(frame['function']).to eq('validate_email')
         expect(frame['platform']).to eq('ruby')
         expect(frame['in_app']).to be true
+      end
+
+      it 'uses Rails.root to make in-app filenames project relative' do
+        rails = Class.new do
+          def self.root
+            '/path/to/project'
+          end
+        end
+        stub_const('Rails', rails)
+
+        line = '/path/to/project/app/services/foo/bar.rb:42'
+        frame = described_class.parse_backtrace_line(line)
+
+        expect(frame['filename']).to eq('app/services/foo/bar.rb')
+      end
+
+      it 'keeps directory structure for files with the same basename' do
+        first_line = "#{File.join(Dir.pwd, 'app/services/foo/bar.rb')}:7"
+        second_line = "#{File.join(Dir.pwd, 'app/jobs/foo/bar.rb')}:8"
+
+        first_frame = described_class.parse_backtrace_line(first_line)
+        second_frame = described_class.parse_backtrace_line(second_line)
+
+        expect(first_frame['filename']).to eq('app/services/foo/bar.rb')
+        expect(second_frame['filename']).to eq('app/jobs/foo/bar.rb')
       end
 
       it 'identifies gem files correctly' do
@@ -24,6 +48,18 @@ module PostHog
         frame = described_class.parse_backtrace_line(gem_line)
 
         expect(frame['in_app']).to be false
+      end
+
+      it 'uses load path relative filenames for gem frames' do
+        gem_lib_path = '/path/to/gems/ruby-3.0.0/lib/ruby/gems/3.0.0/gems/some_gem/lib'
+        gem_line = "#{gem_lib_path}/some_gem/client.rb:10:in `gem_method'"
+        $LOAD_PATH.unshift(gem_lib_path)
+
+        frame = described_class.parse_backtrace_line(gem_line)
+
+        expect(frame['filename']).to eq('some_gem/client.rb')
+      ensure
+        $LOAD_PATH.delete(gem_lib_path)
       end
 
       it 'does not add context lines for non-in_app frames' do
@@ -98,9 +134,11 @@ module PostHog
 
     describe '#build_stacktrace' do
       it 'converts backtrace array to structured frames' do
+        gem_lib_path = '/path/to/gems/ruby-3.0.0/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0/lib'
+        $LOAD_PATH.unshift(gem_lib_path)
         backtrace = [
-          '/path/to/project/app/models/user.rb:42:in `validate_email\'',
-          '/path/to/gems/ruby-3.0.0/lib/ruby/gems/3.0.0/gems/actionpack-7.0.0/lib/action_controller.rb:123:in `dispatch\''
+          "#{File.join(Dir.pwd, 'app/models/user.rb')}:42:in `validate_email'",
+          "#{gem_lib_path}/action_controller.rb:123:in `dispatch'"
         ]
 
         stacktrace = described_class.build_stacktrace(backtrace)
@@ -109,7 +147,9 @@ module PostHog
         expect(stacktrace['frames'].length).to eq(2)
 
         expect(stacktrace['frames'][0]['filename']).to eq('action_controller.rb')
-        expect(stacktrace['frames'][1]['filename']).to eq('user.rb')
+        expect(stacktrace['frames'][1]['filename']).to eq('app/models/user.rb')
+      ensure
+        $LOAD_PATH.delete(gem_lib_path)
       end
     end
 
@@ -165,4 +205,3 @@ module PostHog
     end
   end
 end
-# rubocop:enable Layout/LineLength


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes #212.

Captured exception stack frames currently set `filename` to `File.basename(abs_path)`, which drops project-relative directories such as `app/services/foo/bar.rb`. PostHog Error Tracking renders `filename`, so frames with the same basename become hard to distinguish.

This change preserves useful relative paths for stack frame filenames while keeping `abs_path` unchanged. The changeset covers both `posthog-ruby` and `posthog-rails` because Rails users are affected by the captured exception payload.

## :green_heart: How did you test it?
- `bundle exec rspec spec/posthog/exception_capture_spec.rb`
- `bundle exec rspec`
- `bundle exec rubocop`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent implemented this change in a dedicated git worktree. The implementation follows the issue recommendation by computing stack frame filenames from known roots: Rails.root or the current working directory for in-app frames, and the longest matching `$LOAD_PATH` entry for gem frames. The fallback keeps the original path rather than collapsing to a basename, so directory context is preserved.

Follow-up review feedback replaced the trailing slash regex with a linear implementation, evaluated `Rails.root` only once, and added the Rails changeset entry.
