### PR TITLE
fix: mirror rails request user agent into $raw_user_agent

### DIFF
--- a/.changeset/mirror-raw-user-agent.md
+++ b/.changeset/mirror-raw-user-agent.md
@@ -1,0 +1,5 @@
+---
+"posthog-rails": patch
+---
+
+fix: also send the request user agent as $raw_user_agent, the standardized property PostHog's server-side classification reads

--- a/posthog-rails/lib/posthog/rails/request_metadata.rb
+++ b/posthog-rails/lib/posthog/rails/request_metadata.rb
@@ -18,7 +18,11 @@ module PostHog
         request_method = request_value(request, :request_method) || request_value(request, :method)
         add_property(properties, '$request_method', request_method)
         add_property(properties, '$request_path', request_value(request, :path) || request_value(request, :path_info))
-        add_property(properties, '$user_agent', TracingHeaders.extract_header(request, 'User-Agent'))
+        user_agent = TracingHeaders.extract_header(request, 'User-Agent')
+        add_property(properties, '$user_agent', user_agent)
+        # Mirrored into $raw_user_agent, the standardized property PostHog's
+        # server-side classification (e.g. bot detection) reads
+        add_property(properties, '$raw_user_agent', user_agent)
         add_property(properties, '$ip', client_ip(request))
         properties
       end

--- a/spec/posthog/rails/request_context_spec.rb
+++ b/spec/posthog/rails/request_context_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe PostHog::Rails::RequestContext do
     expect(message[:properties]['$request_method']).to eq('POST')
     expect(message[:properties]['$request_path']).to eq('/api/test')
     expect(message[:properties]['$user_agent']).to eq('RSpec Agent')
+    expect(message[:properties]['$raw_user_agent']).to eq('RSpec Agent')
     expect(message[:properties]['$ip']).to eq('203.0.113.10')
   end
 
@@ -92,6 +93,7 @@ RSpec.describe PostHog::Rails::RequestContext do
     expect(message[:properties]['$session_id']).to be_nil
     expect(message[:properties]['$request_path']).to eq('/api/test')
     expect(message[:properties]['$user_agent']).to eq('RSpec Agent')
+    expect(message[:properties]['$raw_user_agent']).to eq('RSpec Agent')
     expect(message[:properties]['$process_person_profile']).to be false
   end
 
@@ -339,6 +341,7 @@ RSpec.describe PostHog::Rails::RequestContext do
     expect(message[:properties]['$session_id']).to eq('exception-session')
     expect(message[:properties]['$request_path']).to eq('/boom')
     expect(message[:properties]['$user_agent']).to eq('Exception Agent')
+    expect(message[:properties]['$raw_user_agent']).to eq('Exception Agent')
   end
 
   it 'disables tracing headers for exceptions while preserving request metadata' do
@@ -371,6 +374,7 @@ RSpec.describe PostHog::Rails::RequestContext do
     expect(message[:properties]['$process_person_profile']).to be false
     expect(message[:properties]['$request_path']).to eq('/boom')
     expect(message[:properties]['$user_agent']).to eq('Disabled Context Agent')
+    expect(message[:properties]['$raw_user_agent']).to eq('Disabled Context Agent')
     expect(message[:properties]['$ip']).to eq('203.0.113.11')
   end
 end


### PR DESCRIPTION
## :bulb: Motivation and Context

posthog-rails attaches the request's User-Agent to events as `$user_agent`, but PostHog's server-side classification — web analytics bot detection (`$virt_is_bot` and friends) and the materialized-column fast path — keys on the standardized `$raw_user_agent` property (the one posthog-js sends). Server-side-tracked pageviews forwarding a real client UA are exactly the traffic where bot classification matters, and today they miss it.

PostHog/posthog#68253 removes the `$user_agent` query-time fallback for performance (it forced a full properties-blob read on every classification query — see the PR for production measurements), so this change mirrors the header into `$raw_user_agent`, aligning posthog-rails with the standardized property. Related: PostHog/posthog#68232.

`$user_agent` is still sent for backwards compatibility.

## :green_heart: How did you test it?

Agent-authored. Extended the request-context specs to assert `$raw_user_agent` carries the same value in all four scenarios that assert `$user_agent`; relying on CI to run rspec (no compatible local ruby toolchain in this session).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] Changeset added for posthog-rails.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code as part of a cross-repo effort to standardize on `$raw_user_agent` (PostHog/posthog#68232, PostHog/posthog#68253, with sibling PRs to posthog-android and posthog-python).
