### PR TITLE
fix(rails): dedupe ActiveJob exception captures

### DIFF
--- a/.changeset/wise-jobs-raise.md
+++ b/.changeset/wise-jobs-raise.md
@@ -1,0 +1,5 @@
+---
+'posthog-rails': patch
+---
+
+Avoid double-capturing ActiveJob exceptions through the Rails error subscriber.

--- a/posthog-rails/lib/posthog/rails.rb
+++ b/posthog-rails/lib/posthog/rails.rb
@@ -20,6 +20,9 @@ module PostHog
   module Rails
     # Thread-local key for tracking web request context
     IN_WEB_REQUEST_KEY = :posthog_in_web_request
+    ACTIVE_JOB_CAPTURED_EXCEPTION_IVAR = :@posthog_active_job_exception_captured
+
+    private_constant :ACTIVE_JOB_CAPTURED_EXCEPTION_IVAR
 
     class << self
       # @return [PostHog::Rails::Configuration] Rails integration configuration.
@@ -59,6 +62,28 @@ module PostHog
       # @return [Boolean]
       def in_web_request?
         Thread.current[IN_WEB_REQUEST_KEY] == true
+      end
+
+      # Mark an exception as already captured by the ActiveJob integration.
+      # Used by ErrorSubscriber to avoid duplicate captures when Rails reports
+      # the same re-raised job exception via Rails.error.
+      # @api private
+      # @param exception [Exception]
+      # @return [void]
+      def mark_active_job_exception_captured(exception)
+        exception.instance_variable_set(ACTIVE_JOB_CAPTURED_EXCEPTION_IVAR, true)
+      rescue StandardError
+        nil
+      end
+
+      # Check whether an exception was already captured by ActiveJobExtensions.
+      # @api private
+      # @param exception [Exception]
+      # @return [Boolean]
+      def active_job_exception_captured?(exception)
+        exception.instance_variable_get(ACTIVE_JOB_CAPTURED_EXCEPTION_IVAR) == true
+      rescue StandardError
+        false
       end
     end
   end

--- a/posthog-rails/lib/posthog/rails/active_job.rb
+++ b/posthog-rails/lib/posthog/rails/active_job.rb
@@ -70,6 +70,7 @@ module PostHog
           properties,
           mechanism: { 'type' => 'active_job', 'handled' => false }
         )
+        PostHog::Rails.mark_active_job_exception_captured(exception)
       rescue StandardError => e
         # Don't let PostHog errors break job processing
         PostHog::Logging.logger.error("Failed to capture job exception: #{e.message}")

--- a/posthog-rails/lib/posthog/rails/error_subscriber.rb
+++ b/posthog-rails/lib/posthog/rails/error_subscriber.rb
@@ -23,6 +23,8 @@ module PostHog
         # Skip if in a web request - CaptureExceptions middleware will handle it
         # with richer context (URL, params, controller, etc.)
         return if PostHog::Rails.in_web_request?
+        return if PostHog::Rails.config&.auto_instrument_active_job &&
+                  PostHog::Rails.active_job_exception_captured?(error)
 
         distinct_id = context[:user_id] || context[:distinct_id]
 

--- a/spec/posthog/rails/exception_mechanism_spec.rb
+++ b/spec/posthog/rails/exception_mechanism_spec.rb
@@ -62,6 +62,41 @@ RSpec.describe 'automatic exception capture mechanisms' do
         )
       end
     end
+
+    it 'skips exceptions already captured by ActiveJobExtensions' do
+      PostHog::Rails.config.auto_instrument_active_job = true
+      error = StandardError.new('boom')
+      PostHog::Rails.mark_active_job_exception_captured(error)
+
+      described_class.new.report(
+        error,
+        handled: false,
+        severity: :error,
+        context: {},
+        source: 'application.active_support'
+      )
+
+      expect(PostHog).not_to have_received(:capture_exception)
+    end
+
+    it 'still captures unmarked ActiveSupport reports when ActiveJob instrumentation is enabled' do
+      PostHog::Rails.config.auto_instrument_active_job = true
+
+      described_class.new.report(
+        StandardError.new('boom'),
+        handled: false,
+        severity: :error,
+        context: {},
+        source: 'application.active_support'
+      )
+
+      expect(PostHog).to have_received(:capture_exception).with(
+        an_instance_of(StandardError),
+        anything,
+        hash_including('$exception_source' => 'application.active_support'),
+        mechanism: { 'type' => 'rails_error_reporter', 'handled' => false }
+      )
+    end
   end
 
   describe PostHog::Rails::ActiveJobExtensions do
@@ -109,6 +144,33 @@ RSpec.describe 'automatic exception capture mechanisms' do
         an_instance_of(StandardError),
         anything,
         an_instance_of(Hash),
+        mechanism: { 'type' => 'active_job', 'handled' => false }
+      )
+    end
+
+    it 'prevents Rails error subscriber from capturing the same job exception again' do
+      PostHog::Rails.config.auto_instrument_active_job = true
+      error = nil
+
+      begin
+        job_class.new.perform_now
+      rescue StandardError => e
+        error = e
+      end
+
+      PostHog::Rails::ErrorSubscriber.new.report(
+        error,
+        handled: false,
+        severity: :error,
+        context: {},
+        source: 'application.active_support'
+      )
+
+      expect(PostHog).to have_received(:capture_exception).once
+      expect(PostHog).to have_received(:capture_exception).with(
+        an_instance_of(StandardError),
+        anything,
+        hash_including('$exception_source' => 'active_job'),
         mechanism: { 'type' => 'active_job', 'handled' => false }
       )
     end


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes https://github.com/PostHog/posthog-ruby/issues/217.

When both Rails exception auto-capture and ActiveJob instrumentation are enabled, a failing job can be captured once by `ActiveJobExtensions` and again when Rails reports the same re-raised exception through `Rails.error` with source `application.active_support`.

This PR marks exceptions successfully captured by the ActiveJob integration and has the Rails error subscriber skip only those already-captured exceptions. Unmarked `application.active_support` reports continue to be captured normally.

## :green_heart: How did you test it?

- `BUNDLE_PATH=/Users/marandaneto/Github/posthog-ruby/vendor/bundle bundle exec rspec --format doc spec/posthog/rails/exception_mechanism_spec.rb`
- `BUNDLE_PATH=/Users/marandaneto/Github/posthog-ruby/vendor/bundle bundle exec rubocop posthog-rails/lib/posthog/rails.rb posthog-rails/lib/posthog/rails/active_job.rb posthog-rails/lib/posthog/rails/error_subscriber.rb spec/posthog/rails/exception_mechanism_spec.rb`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi. I chose an exception-level marker instead of skipping all `application.active_support` reports so unrelated Rails error reports are not suppressed. The tests cover the duplicate ActiveJob path and confirm unmarked ActiveSupport reports still pass through the Rails error subscriber.
