### PR TITLE
feat(flags): minimize $feature_flag_called events for non-experiment flags

### DIFF
--- a/.changeset/minimal-flag-called-events.md
+++ b/.changeset/minimal-flag-called-events.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": minor
+---
+
+feat: emit minimal `$feature_flag_called` events when the server enables the `minimal_flag_called_events` gate and the evaluated flag has no linked experiment. Minimal events keep a strict allowlist of flag-evaluation properties and strip everything else (context properties, `$feature/<key>`, payloads, system metadata). The gate is read from the top-level `minimalFlagCalledEvents` field of the v2 `/flags` response and the top-level `minimal_flag_called_events` key of the local evaluation definitions payload; when either signal is missing, the full event is sent unchanged.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -22,6 +22,31 @@ module PostHog
     include PostHog::Utils
     include PostHog::Logging
 
+    # Strict allowlist of properties kept on minimal `$feature_flag_called`
+    # events (server-gated, non-experiment flags only). Everything else —
+    # context properties, `$feature/<key>`, payloads, system metadata — is
+    # stripped. Includes symbol forms so allowlisted properties supplied
+    # through context with symbol keys survive.
+    MINIMAL_FLAG_CALLED_EVENT_PROPERTIES = %w[
+      $feature_flag
+      $feature_flag_response
+      $feature_flag_has_experiment
+      $feature_flag_id
+      $feature_flag_version
+      $feature_flag_reason
+      $feature_flag_request_id
+      $feature_flag_evaluated_at
+      $feature_flag_error
+      locally_evaluated
+      $groups
+      $process_person_profile
+      $session_id
+      $is_server
+      $lib
+      $lib_version
+    ].flat_map { |key| [key, key.to_sym] }.freeze
+    private_constant :MINIMAL_FLAG_CALLED_EVENT_PROPERTIES
+
     # Thread-safe tracking of client instances per API key for singleton warnings
     @instances_by_api_key = {}
     @instances_mutex = Mutex.new
@@ -253,6 +278,7 @@ module PostHog
       return false if @disabled
 
       symbolize_keys! attrs
+      minimal_flag_called_event = attrs.delete(:_minimal_flag_called_event) == true
       enrich_capture_attrs_with_context(attrs)
 
       # Precedence: an explicit `flags` snapshot always wins, regardless of
@@ -321,7 +347,13 @@ module PostHog
       end
 
       attrs[:is_server] = @is_server
-      enqueue(FieldParser.parse_for_capture(attrs))
+      message = FieldParser.parse_for_capture(attrs)
+      # Minimal events are built from the allowlist after full assembly so
+      # context properties and parser-added metadata can never leak in.
+      if minimal_flag_called_event
+        message[:properties] = message[:properties].slice(*MINIMAL_FLAG_CALLED_EVENT_PROPERTIES)
+      end
+      enqueue(message)
     end
 
     # Captures an exception as an event
@@ -627,6 +659,11 @@ module PostHog
       evaluated_at = nil
       errors_while_computing = false
       quota_limited = false
+      # Server-controlled gate for minimal `$feature_flag_called` events. When
+      # the snapshot uses a remote /flags response, the response's top-level
+      # `minimalFlagCalledEvents` field governs; a local-only snapshot reads
+      # the gate polled with the flag definitions.
+      minimal_flag_called_events = @feature_flags_poller.minimal_flag_called_events
 
       # Skip the remote `/flags` round-trip when the caller scoped the request
       # to a fixed set of `flag_keys` and we've already resolved every one of
@@ -635,10 +672,16 @@ module PostHog
       all_requested_flags_resolved_locally = flag_keys_set && (flag_keys_set - locally_evaluated_keys).empty?
 
       if !only_evaluate_locally && !all_requested_flags_resolved_locally
+        # The gate is team-level, so the /flags response gate supersedes the
+        # poller gate for mixed snapshots — both signals come from the same
+        # server and agree in steady state. When the response omits the gate,
+        # the whole snapshot fails safe to full events.
+        minimal_flag_called_events = false
         begin
           flags_response = @feature_flags_poller.get_flags(
             distinct_id, groups, person_properties, group_properties, flag_keys, disable_geoip
           )
+          minimal_flag_called_events = flags_response[:minimalFlagCalledEvents] == true
           request_id = flags_response[:requestId]
           evaluated_at = flags_response[:evaluatedAt]
           errors_while_computing = flags_response[:errorsWhileComputingFlags] == true
@@ -677,7 +720,8 @@ module PostHog
         evaluated_at: evaluated_at,
         flag_definitions_loaded_at: @feature_flags_poller.flag_definitions_loaded_at,
         errors_while_computing: errors_while_computing,
-        quota_limited: quota_limited
+        quota_limited: quota_limited,
+        minimal_flag_called_events: minimal_flag_called_events
       )
     end
 
@@ -777,6 +821,7 @@ module PostHog
       response.delete(:requestId)
       response.delete(:evaluatedAt)
       response.delete(:flagDetails)
+      response.delete(:minimalFlagCalledEvents)
       response
     end
 
@@ -885,7 +930,7 @@ module PostHog
     # separate event for each group a user is evaluated under.
     def _capture_feature_flag_called_if_needed(
       distinct_id: nil, key: nil, response: nil, properties: nil,
-      groups: nil, disable_geoip: nil
+      groups: nil, disable_geoip: nil, minimal: false
     )
       response_repr = response.nil? ? '::null::' : response
       groups_repr =
@@ -915,6 +960,7 @@ module PostHog
       }
       msg[:groups] = groups if groups
       msg[:disable_geoip] = disable_geoip unless disable_geoip.nil?
+      msg[:_minimal_flag_called_event] = true if minimal
 
       capture(msg)
     end
@@ -945,7 +991,7 @@ module PostHog
         groups, person_properties, group_properties
       )
       feature_flag_response, flag_was_locally_evaluated, request_id, evaluated_at, feature_flag_error, payload,
-        has_experiment =
+        has_experiment, minimal_flag_called_events =
         @feature_flags_poller.get_feature_flag(
           key, distinct_id, groups, person_properties, group_properties, only_evaluate_locally
         )
@@ -960,9 +1006,13 @@ module PostHog
         properties['$feature_flag_evaluated_at'] = evaluated_at if evaluated_at
         properties['$feature_flag_error'] = feature_flag_error if feature_flag_error
 
+        # Emit a minimal event only when the server gate is on and the flag is
+        # known to have no linked experiment. Any missing signal fails safe to
+        # the full event.
+        minimal = minimal_flag_called_events == true && has_experiment == false
         _capture_feature_flag_called_if_needed(
           distinct_id: distinct_id, key: key, response: feature_flag_response,
-          properties: properties, groups: groups
+          properties: properties, groups: groups, minimal: minimal
         )
       end
 

--- a/lib/posthog/feature_flag_evaluations.rb
+++ b/lib/posthog/feature_flag_evaluations.rb
@@ -44,6 +44,8 @@ module PostHog
     # @param flag_definitions_loaded_at [Time, nil] When local flag definitions were loaded.
     # @param errors_while_computing [Boolean] Whether the server reported errors while computing flags.
     # @param quota_limited [Boolean] Whether feature flag evaluation was quota limited.
+    # @param minimal_flag_called_events [Boolean] Server-controlled gate for minimal
+    #   `$feature_flag_called` events.
     # @param accessed [Array<String>, Set<String>, nil] Flag keys already accessed by this snapshot.
     def initialize(
       host: nil,
@@ -56,6 +58,7 @@ module PostHog
       flag_definitions_loaded_at: nil,
       errors_while_computing: false,
       quota_limited: false,
+      minimal_flag_called_events: false,
       accessed: nil
     )
       @host = host
@@ -68,6 +71,7 @@ module PostHog
       @flag_definitions_loaded_at = flag_definitions_loaded_at
       @errors_while_computing = errors_while_computing
       @quota_limited = quota_limited
+      @minimal_flag_called_events = minimal_flag_called_events == true
       @accessed = Set.new(accessed || [])
     end
 
@@ -188,13 +192,19 @@ module PostHog
       errors << 'flag_missing' if flag.nil?
       properties['$feature_flag_error'] = errors.join(',') unless errors.empty?
 
+      # Emit a minimal event only when the server gate is on and the flag is
+      # known to have no linked experiment. Any missing signal (unknown flag,
+      # has_experiment absent) fails safe to the full event.
+      minimal = @minimal_flag_called_events && !flag.nil? && flag.has_experiment == false
+
       @host.capture_flag_called_event_if_needed.call(
         distinct_id: @distinct_id,
         key: key,
         response: response,
         properties: properties,
         groups: @groups,
-        disable_geoip: @disable_geoip
+        disable_geoip: @disable_geoip,
+        minimal: minimal
       )
     end
 
@@ -210,6 +220,7 @@ module PostHog
         flag_definitions_loaded_at: @flag_definitions_loaded_at,
         errors_while_computing: @errors_while_computing,
         quota_limited: @quota_limited,
+        minimal_flag_called_events: @minimal_flag_called_events,
         accessed: @accessed.dup
       )
     end

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -115,6 +115,7 @@ module PostHog
     end
 
     attr_reader :feature_flags_by_key, :minimal_flag_called_events
+
     def get_feature_variants(
       distinct_id,
       groups = {},

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -72,7 +72,10 @@ module PostHog
       @flags_etag = Concurrent::AtomicReference.new(nil)
       @flag_definitions_loaded_at = Concurrent::AtomicReference.new(nil)
       @async_load = async_load
-
+      # Server-controlled gate for minimal `$feature_flag_called` events, read
+      # from the top-level `minimal_flag_called_events` key of the local
+      # evaluation definitions payload. false when the server does not send it.
+      @minimal_flag_called_events = false
       @flag_definition_cache_provider = flag_definition_cache_provider
       FlagDefinitionCacheProvider.validate!(@flag_definition_cache_provider) if @flag_definition_cache_provider
 
@@ -111,8 +114,7 @@ module PostHog
       @flag_definitions_loaded_at.value
     end
 
-    attr_reader :feature_flags_by_key
-
+    attr_reader :feature_flags_by_key, :minimal_flag_called_events
     def get_feature_variants(
       distinct_id,
       groups = {},
@@ -245,6 +247,11 @@ module PostHog
       # evaluated flags carry it in the response metadata. nil when the server
       # (an older deployment) does not report it.
       has_experiment = feature_flag[:has_experiment] if flag_was_locally_evaluated
+      # Server-controlled gate for minimal `$feature_flag_called` events.
+      # Locally-evaluated flags read it from the definitions payload; remotely
+      # evaluated flags read it from the /flags response. nil when the signal
+      # is unavailable, which fails safe to the full event.
+      minimal_flag_called_events = @minimal_flag_called_events if flag_was_locally_evaluated
 
       request_id = nil
       evaluated_at = nil
@@ -279,6 +286,7 @@ module PostHog
 
           flag_detail = flags_data[:flagDetails]&.[](key.to_sym)
           has_experiment = flag_detail&.metadata&.has_experiment
+          minimal_flag_called_events = flags_data[:minimalFlagCalledEvents]
 
           logger.debug "Successfully computed flag remotely: #{key} -> #{response}"
         rescue Timeout::Error => e
@@ -293,7 +301,8 @@ module PostHog
         end
       end
 
-      [response, flag_was_locally_evaluated, request_id, evaluated_at, feature_flag_error, payload, has_experiment]
+      [response, flag_was_locally_evaluated, request_id, evaluated_at, feature_flag_error, payload, has_experiment,
+       minimal_flag_called_events]
     end
 
     def get_all_flags(
@@ -352,6 +361,7 @@ module PostHog
       quota_limited = nil
       status_code = nil
       flag_details = nil
+      minimal_flag_called_events = nil
 
       if fallback_to_server && !only_evaluate_locally
         begin
@@ -367,6 +377,7 @@ module PostHog
 
           request_id = flags_and_payloads[:requestId]
           evaluated_at = flags_and_payloads[:evaluatedAt]
+          minimal_flag_called_events = flags_and_payloads[:minimalFlagCalledEvents]
 
           # Check if feature_flags are quota limited
           if quota_limited&.include?('feature_flags')
@@ -402,7 +413,8 @@ module PostHog
         evaluatedAt: evaluated_at,
         errorsWhileComputingFlags: errors_while_computing,
         quotaLimited: quota_limited,
-        status: status_code
+        status: status_code,
+        minimalFlagCalledEvents: minimal_flag_called_events
       }
     end
 
@@ -1203,6 +1215,7 @@ module PostHog
         @group_type_mapping = Concurrent::Hash.new
         @cohorts = Concurrent::Hash.new
         @flag_definitions_loaded_at.value = nil
+        @minimal_flag_called_events = false
         @loaded_flags_successfully_once.make_false
         @quota_limited.make_true
         return
@@ -1226,7 +1239,8 @@ module PostHog
         data = {
           flags: @feature_flags.to_a,
           group_type_mapping: @group_type_mapping.to_h,
-          cohorts: @cohorts.to_h
+          cohorts: @cohorts.to_h,
+          minimal_flag_called_events: @minimal_flag_called_events
         }
         @flag_definition_cache_provider.on_flag_definitions_received(data)
       rescue StandardError => e
@@ -1238,6 +1252,7 @@ module PostHog
       flags = get_by_symbol_or_string_key(data, 'flags') || []
       group_type_mapping = get_by_symbol_or_string_key(data, 'group_type_mapping') || {}
       cohorts = get_by_symbol_or_string_key(data, 'cohorts') || {}
+      minimal_flag_called_events = get_by_symbol_or_string_key(data, 'minimal_flag_called_events')
 
       @feature_flags = Concurrent::Array.new(flags.map { |f| deep_symbolize_keys(f) })
 
@@ -1249,6 +1264,7 @@ module PostHog
 
       @group_type_mapping = Concurrent::Hash[deep_symbolize_keys(group_type_mapping)]
       @cohorts = Concurrent::Hash[deep_symbolize_keys(cohorts)]
+      @minimal_flag_called_events = minimal_flag_called_events == true
 
       logger.debug "Loaded #{@feature_flags.length} feature flags and #{@cohorts.length} cohorts"
       @flag_definitions_loaded_at.value = (Time.now.to_f * 1000).to_i

--- a/lib/posthog/flag_definition_cache.rb
+++ b/lib/posthog/flag_definition_cache.rb
@@ -14,9 +14,9 @@ module PostHog
   #
   # @!method flag_definitions
   #   Retrieve cached flag definitions. Return a Hash with +:flags+,
-  #   +:group_type_mapping+, and +:cohorts+ keys, or +nil+ if the cache
-  #   is empty. Returning +nil+ triggers an API fetch when no flags are
-  #   loaded yet (emergency fallback).
+  #   +:group_type_mapping+, +:cohorts+, and +:minimal_flag_called_events+
+  #   keys, or +nil+ if the cache is empty. Returning +nil+ triggers an API
+  #   fetch when no flags are loaded yet (emergency fallback).
   #   @return [Hash, nil]
   #
   # @!method should_fetch_flag_definitions?
@@ -27,9 +27,9 @@ module PostHog
   #
   # @!method on_flag_definitions_received(data)
   #   Called after successfully fetching new definitions from the API.
-  #   +data+ is a Hash with +:flags+, +:group_type_mapping+, and +:cohorts+
-  #   keys (plain Ruby types, not Concurrent:: wrappers). Store it in your
-  #   external cache.
+  #   +data+ is a Hash with +:flags+, +:group_type_mapping+, +:cohorts+, and
+  #   +:minimal_flag_called_events+ keys (plain Ruby types, not Concurrent::
+  #   wrappers). Store it in your external cache.
   #   @param data [Hash]
   #   @return [void]
   #

--- a/lib/posthog/flag_definition_cache.rb
+++ b/lib/posthog/flag_definition_cache.rb
@@ -16,7 +16,9 @@ module PostHog
   #   Retrieve cached flag definitions. Return a Hash with +:flags+,
   #   +:group_type_mapping+, +:cohorts+, and +:minimal_flag_called_events+
   #   keys, or +nil+ if the cache is empty. Returning +nil+ triggers an API
-  #   fetch when no flags are loaded yet (emergency fallback).
+  #   fetch when no flags are loaded yet (emergency fallback). Providers
+  #   written before +:minimal_flag_called_events+ existed continue to work;
+  #   a missing key is treated as +false+.
   #   @return [Hash, nil]
   #
   # @!method should_fetch_flag_definitions?

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -290,6 +290,24 @@ module PostHog
         )
       end
 
+      it 'does not minimize when a caller supplies the minimal marker inside properties' do
+        client.capture(
+          distinct_id: 'user',
+          event: '$feature_flag_called',
+          properties: {
+            '_minimal_flag_called_event' => true,
+            '$feature_flag' => 'test-flag',
+            'custom_prop' => 'value'
+          }
+        )
+
+        message = client.dequeue_last_message
+        # Both properties would be stripped by the allowlist if the smuggled
+        # marker had triggered minimization.
+        expect(message[:properties]['custom_prop']).to eq('value')
+        expect(message[:properties]['_minimal_flag_called_event']).to be true
+      end
+
       it 'generates a personless distinct_id without an explicit or context distinct_id' do
         client.capture(event: 'Event')
 

--- a/spec/posthog/feature_flag_evaluations_spec.rb
+++ b/spec/posthog/feature_flag_evaluations_spec.rb
@@ -42,6 +42,14 @@ module PostHog
       msgs
     end
 
+    def flag_called_properties(client, key)
+      client.evaluate_flags('user-1').enabled?(key)
+      event = drain_messages(client).find do |m|
+        m[:event] == '$feature_flag_called' && m[:properties]['$feature_flag'] == key
+      end
+      event[:properties]
+    end
+
     def capture_stderr
       original = $stderr
       $stderr = StringIO.new
@@ -325,14 +333,6 @@ module PostHog
         }
       end
 
-      def flag_called_properties(client, key)
-        client.evaluate_flags('user-1').enabled?(key)
-        event = drain_messages(client).find do |m|
-          m[:event] == '$feature_flag_called' && m[:properties]['$feature_flag'] == key
-        end
-        event[:properties]
-      end
-
       it 'is true when the server reports has_experiment' do
         stub_flags(has_experiment_response)
         expect(flag_called_properties(client, 'experiment-flag')['$feature_flag_has_experiment']).to be(true)
@@ -375,14 +375,6 @@ module PostHog
           requestId: 'request-id-3',
           minimalFlagCalledEvents: true
         }
-      end
-
-      def flag_called_properties(client, key)
-        client.evaluate_flags('user-1').enabled?(key)
-        event = drain_messages(client).find do |m|
-          m[:event] == '$feature_flag_called' && m[:properties]['$feature_flag'] == key
-        end
-        event[:properties]
       end
 
       it 'sends only the allowlisted properties for a gated flag without an experiment' do
@@ -434,6 +426,17 @@ module PostHog
              $feature_flag_reason $groups $is_server locally_evaluated $lib $lib_version]
         )
         expect(properties['locally_evaluated']).to be(true)
+      end
+
+      it 'does not leak a true poller gate into a mixed snapshot when the /flags response omits it' do
+        stub_request(:get, %r{https://us\.i\.posthog\.com/flags/definitions})
+          .to_return(status: 200, body: { 'flags' => [], 'minimal_flag_called_events' => true }.to_json)
+        stub_flags(gated_response.except(:minimalFlagCalledEvents))
+        mixed_client = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+        properties = flag_called_properties(mixed_client, 'plain-flag')
+
+        expect(properties['$feature/plain-flag']).to be(true)
       end
     end
 

--- a/spec/posthog/feature_flag_evaluations_spec.rb
+++ b/spec/posthog/feature_flag_evaluations_spec.rb
@@ -354,6 +354,89 @@ module PostHog
       end
     end
 
+    describe 'minimal $feature_flag_called events' do
+      let(:gated_response) do
+        {
+          flags: {
+            'plain-flag' => {
+              key: 'plain-flag', enabled: true, variant: nil,
+              reason: { code: 'condition_match', condition_index: 1, description: 'Matched condition set 1' },
+              metadata: { id: 11, version: 2, payload: '{"key": "value"}', has_experiment: false }
+            },
+            'experiment-flag' => {
+              key: 'experiment-flag', enabled: true, variant: nil,
+              metadata: { id: 10, version: 1, has_experiment: true }
+            },
+            'legacy-flag' => {
+              key: 'legacy-flag', enabled: true, variant: nil,
+              metadata: { id: 12, version: 1 }
+            }
+          },
+          requestId: 'request-id-3',
+          minimalFlagCalledEvents: true
+        }
+      end
+
+      def flag_called_properties(client, key)
+        client.evaluate_flags('user-1').enabled?(key)
+        event = drain_messages(client).find do |m|
+          m[:event] == '$feature_flag_called' && m[:properties]['$feature_flag'] == key
+        end
+        event[:properties]
+      end
+
+      it 'sends only the allowlisted properties for a gated flag without an experiment' do
+        stub_flags(gated_response)
+        properties = flag_called_properties(client, 'plain-flag')
+        expect(properties.keys).to match_array(
+          %w[$feature_flag $feature_flag_response $feature_flag_has_experiment $feature_flag_id
+             $feature_flag_version $feature_flag_reason $feature_flag_request_id $groups $is_server
+             locally_evaluated $lib $lib_version]
+        )
+        expect(properties['$feature_flag_has_experiment']).to be(false)
+      end
+
+      it 'sends the full event for a gated flag with an experiment' do
+        stub_flags(gated_response)
+        properties = flag_called_properties(client, 'experiment-flag')
+        expect(properties['$feature_flag_has_experiment']).to be(true)
+        expect(properties['$feature/experiment-flag']).to be(true)
+      end
+
+      it 'sends the full event when the flag does not report has_experiment' do
+        stub_flags(gated_response)
+        expect(flag_called_properties(client, 'legacy-flag')['$feature/legacy-flag']).to be(true)
+      end
+
+      it 'sends the full event when the /flags response omits the gate' do
+        stub_flags(gated_response.except(:minimalFlagCalledEvents))
+        expect(flag_called_properties(client, 'plain-flag')['$feature/plain-flag']).to be(true)
+      end
+
+      it 'reads the gate from the local evaluation definitions payload' do
+        stub_request(:get, 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true')
+          .to_return(status: 200, body: {
+            'flags' => [{
+              'id' => 1, 'key' => 'local-flag', 'active' => true, 'has_experiment' => false,
+              'filters' => { 'groups' => [{ 'rollout_percentage' => 100 }] }
+            }],
+            'minimal_flag_called_events' => true
+          }.to_json)
+        local_client = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+        snapshot = local_client.evaluate_flags('user-1', only_evaluate_locally: true)
+        expect(snapshot.enabled?('local-flag')).to be(true)
+
+        event = drain_messages(local_client).find { |m| m[:event] == '$feature_flag_called' }
+        properties = event[:properties]
+        expect(properties.keys).to match_array(
+          %w[$feature_flag $feature_flag_response $feature_flag_has_experiment $feature_flag_id
+             $feature_flag_reason $groups $is_server locally_evaluated $lib $lib_version]
+        )
+        expect(properties['locally_evaluated']).to be(true)
+      end
+    end
+
     describe 'response-level errors' do
       it 'combines errorsWhileComputingFlags with flag_missing on $feature_flag_error' do
         stub_flags(flags_response.merge(errorsWhileComputingFlags: true))

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -5348,6 +5348,135 @@ module PostHog
         expect(flag_called_properties(c, 'remote-flag')).not_to have_key('$feature_flag_has_experiment')
       end
     end
+
+    describe 'minimal $feature_flag_called events' do
+      def local_definitions(has_experiment: false, minimal_flag_called_events: true)
+        flag = {
+          'id' => 1,
+          'name' => 'Beta Feature',
+          'key' => 'test-flag',
+          'active' => true,
+          'filters' => { 'groups' => [{ 'rollout_percentage' => 100 }] }
+        }
+        flag['has_experiment'] = has_experiment unless has_experiment.nil?
+        definitions = { 'flags' => [flag] }
+        definitions['minimal_flag_called_events'] = minimal_flag_called_events unless minimal_flag_called_events.nil?
+        definitions
+      end
+
+      def remote_flags_response(has_experiment: false, minimal_flag_called_events: true)
+        metadata = { 'id' => 7, 'version' => 3 }
+        metadata['has_experiment'] = has_experiment unless has_experiment.nil?
+        response = {
+          'flags' => {
+            'remote-flag' => { 'key' => 'remote-flag', 'enabled' => true, 'variant' => nil, 'metadata' => metadata }
+          },
+          'requestId' => 'test-request-id'
+        }
+        response['minimalFlagCalledEvents'] = minimal_flag_called_events unless minimal_flag_called_events.nil?
+        response
+      end
+
+      def stub_definitions(body)
+        stub_request(
+          :get,
+          'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
+        ).to_return(status: 200, body: body.to_json)
+      end
+
+      def flag_called_properties(client, key, groups: {})
+        Internal::Context.with_context(session_id: 'session-abc', properties: { 'custom_context_prop' => 'value' }) do
+          client.get_feature_flag_result(key, 'some-distinct-id', groups: groups)
+        end
+        captured_message = client.dequeue_last_message
+        expect(captured_message[:event]).to eq('$feature_flag_called')
+        captured_message[:properties]
+      end
+
+      context 'with local evaluation' do
+        it 'sends only the allowlisted properties when gated and the flag has no experiment' do
+          stub_definitions(local_definitions)
+          c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+          properties = flag_called_properties(c, 'test-flag')
+          expect(properties.keys).to match_array(
+            %w[$feature_flag $feature_flag_response $feature_flag_has_experiment $groups $session_id
+               $is_server locally_evaluated $lib $lib_version]
+          )
+          expect(properties['$feature_flag_response']).to be true
+          expect(properties['$feature_flag_has_experiment']).to be false
+          expect(properties['locally_evaluated']).to be true
+          expect(properties['$session_id']).to eq('session-abc')
+          expect(properties['$is_server']).to be true
+        end
+
+        it 'keeps $groups on minimal events' do
+          stub_definitions(local_definitions)
+          c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+          properties = flag_called_properties(c, 'test-flag', groups: { 'company' => 'id_5' })
+          expect(properties['$groups']).to eq(company: 'id_5')
+        end
+
+        it 'sends the full event when the flag has an experiment' do
+          stub_definitions(local_definitions(has_experiment: true))
+          c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+          properties = flag_called_properties(c, 'test-flag')
+          expect(properties['$feature_flag_has_experiment']).to be true
+          expect(properties['custom_context_prop']).to eq('value')
+        end
+
+        it 'sends the full event when the definitions payload omits the gate' do
+          stub_definitions(local_definitions(minimal_flag_called_events: nil))
+          c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+          expect(flag_called_properties(c, 'test-flag')['custom_context_prop']).to eq('value')
+        end
+
+        it 'sends the full event when the flag does not report has_experiment' do
+          stub_definitions(local_definitions(has_experiment: nil))
+          c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+          expect(flag_called_properties(c, 'test-flag')['custom_context_prop']).to eq('value')
+        end
+      end
+
+      context 'with remote evaluation' do
+        before { stub_definitions('flags' => []) }
+
+        it 'sends only the allowlisted properties when the /flags response gates and reports no experiment' do
+          stub_request(:post, flags_endpoint).to_return(status: 200, body: remote_flags_response.to_json)
+          c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+          properties = flag_called_properties(c, 'remote-flag')
+          expect(properties.keys).to match_array(
+            %w[$feature_flag $feature_flag_response $feature_flag_has_experiment $feature_flag_request_id
+               $groups $session_id $is_server locally_evaluated $lib $lib_version]
+          )
+          expect(properties['$feature_flag_has_experiment']).to be false
+          expect(properties['locally_evaluated']).to be false
+        end
+
+        it 'sends the full event when the /flags response reports an experiment' do
+          stub_request(:post, flags_endpoint)
+            .to_return(status: 200, body: remote_flags_response(has_experiment: true).to_json)
+          c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+          properties = flag_called_properties(c, 'remote-flag')
+          expect(properties['$feature_flag_has_experiment']).to be true
+          expect(properties['custom_context_prop']).to eq('value')
+        end
+
+        it 'sends the full event when the /flags response omits the gate' do
+          stub_request(:post, flags_endpoint)
+            .to_return(status: 200, body: remote_flags_response(minimal_flag_called_events: nil).to_json)
+          c = Client.new(api_key: API_KEY, personal_api_key: API_KEY, test_mode: true)
+
+          expect(flag_called_properties(c, 'remote-flag')['custom_context_prop']).to eq('value')
+        end
+      end
+    end
   end
 
   describe 'definitions polling interval' do

--- a/spec/posthog/flag_definition_cache_spec.rb
+++ b/spec/posthog/flag_definition_cache_spec.rb
@@ -412,6 +412,25 @@ module PostHog
         expect(cohorts[:'1'][:type]).to eq('AND')
       end
 
+      it 'persists the minimal_flag_called_events gate to the cache provider' do
+        provider.should_fetch_return_value = true
+
+        stub_request(:get, local_eval_url)
+          .to_return(status: 200, body: sample_flags_data.merge('minimal_flag_called_events' => true).to_json)
+        create_client_with_cache(provider: provider, stub_api: false)
+
+        expect(provider.stored_data[:minimal_flag_called_events]).to eq(true)
+      end
+
+      it 'applies the minimal_flag_called_events gate from cached data' do
+        provider.should_fetch_return_value = false
+        provider.stored_data = sample_flags_data.merge('minimal_flag_called_events' => true)
+
+        client = create_client_with_cache(provider: provider, stub_api: false)
+
+        expect(get_poller(client).minimal_flag_called_events).to eq(true)
+      end
+
       it 'updates cache when API returns new data' do
         provider.should_fetch_return_value = true
 

--- a/spec/posthog/flags_spec.rb
+++ b/spec/posthog/flags_spec.rb
@@ -1940,6 +1940,23 @@ module PostHog
         expect(poller.instance_variable_get(:@group_type_mapping)).to eq({ '0': 'company' })
       end
 
+      it 'preserves the minimal_flag_called_events gate across a 304 Not Modified response' do
+        beta_flags = { flags: [{ id: 1, key: 'beta-feature', active: true }],
+                       group_type_mapping: {}, cohorts: {}, minimal_flag_called_events: true }
+        stub_request(:get, feature_flag_endpoint)
+          .to_return(
+            { status: 200, body: beta_flags.to_json, headers: { 'ETag' => '"test-etag"' } },
+            { status: 304, body: '', headers: { 'ETag' => '"test-etag"' } }
+          )
+
+        poller.load_feature_flags(true)
+        expect(poller.minimal_flag_called_events).to be(true)
+
+        poller.load_feature_flags(true)
+
+        expect(poller.minimal_flag_called_events).to be(true)
+      end
+
       it 'updates ETag when flags change' do
         # Need 3 responses: 1 for client initialization, 2 for the test
         empty_flags = { flags: [], group_type_mapping: {}, cohorts: {} }


### PR DESCRIPTION
## :bulb: Motivation and Context

`$feature_flag_called` events carry the full enriched properties dict (rails request context, super/context properties, custom event properties) on every flag call, even for flags not linked to an experiment. This PR trims those events to a strict allowlist iff the server-controlled gate is on (`minimalFlagCalledEvents` in the v2 `/flags` response, or top-level `minimal_flag_called_events` in the local-evaluation flag definitions payload) and the evaluated flag's `has_experiment` is exactly `false`. Any missing signal (gate absent, `has_experiment` unknown, legacy response shape, request failure) sends the full legacy shape unchanged.

Server-gated because rolling this out unconditionally could break existing insights; announcement/comms come before enablement. The goal is to establish `$feature_flag_called` as a special system event.

Implementation notes:

- **Single enforcement point**: minimal events are built by slicing the allowlist in `Client#capture` after context merge and `FieldParser` assembly, so context properties and parser-added metadata can never leak in. Kept: `$feature_flag`, `$feature_flag_response`, `$feature_flag_has_experiment`, `$feature_flag_id`, `$feature_flag_version`, `$feature_flag_reason`, `$feature_flag_request_id`, `$feature_flag_evaluated_at`, `$feature_flag_error`, `locally_evaluated`, `$groups`, `$process_person_profile`, `$session_id`, `$is_server`, `$lib`, `$lib_version` (string and symbol forms).
- **Local-evaluation gate** lives on the poller: refreshed on each definitions poll, preserved across 304 Not Modified responses, reset when flags are unset on quota limit, and persisted through `flag_definition_cache_provider` implementations so it survives restarts in multi-worker setups.
- **Remote evaluation** reads the gate per `/flags` response. For mixed snapshots (`evaluate_flags`), the team-level response gate supersedes the poller gate; a response without the gate fails the whole snapshot safe to full events.
- Both `$feature_flag_called` emit paths are covered: the legacy single-flag path (`get_feature_flag_result` and friends) and the snapshot path (`evaluate_flags` / `FeatureFlagEvaluations`).

Part of a cross-SDK rollout; reference implementation and fuller context: PostHog/posthog-python#748

## :green_heart: How did you test it?

- `bundle exec rspec` — 630 examples, 0 failures
- `bundle exec rubocop` — 82 files inspected, no offenses
- `bundle exec rake public_api:check` — passing (no public API surface changes)

Coverage added:

- Gate matrix from both signal sources (local-eval definitions payload and v2 `/flags` response), across both emit paths: gated + no experiment → minimal; gated + experiment → full; gate missing / `has_experiment` missing → full.
- Exact-key-set assertions on minimal events, including `$session_id` and `$is_server` retention and stripping of context properties, `$feature/<key>`, and payload props.
- Regression test proving a caller-supplied `_minimal_flag_called_event` key inside `capture` properties cannot trigger minimization.
- Cache-provider tests simulating restart: gate stored on fetch, applied when definitions load from cached data.

Released as a `minor` changeset for `posthog-ruby`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
