### PR TITLE
fix(flags): pass the resolved polling interval to the definitions poll timer

### DIFF
--- a/.changeset/polling-interval-default.md
+++ b/.changeset/polling-interval-default.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": patch
+---
+
+fix: honor the documented 30s default for `feature_flags_polling_interval`. The resolved default was computed but never passed to the polling timer, so when the option was unset the effective interval was concurrent-ruby's 60s TimerTask default. Definitions now poll every 30s by default as documented; set `feature_flags_polling_interval: 60` to keep the previous effective cadence.

--- a/.changeset/polling-interval-default.md
+++ b/.changeset/polling-interval-default.md
@@ -2,4 +2,4 @@
 "posthog-ruby": patch
 ---
 
-fix: honor the documented 30s default for `feature_flags_polling_interval`. The resolved default was computed but never passed to the polling timer, so when the option was unset the effective interval was concurrent-ruby's 60s TimerTask default. Definitions now poll every 30s by default as documented; set `feature_flags_polling_interval: 60` to keep the previous effective cadence.
+Honor the documented 30s default for `feature_flags_polling_interval`. The resolved default was computed but never passed to the polling timer, so when the option was unset the effective interval was concurrent-ruby's 60s TimerTask default. Definitions now poll every 30s by default as documented; set `feature_flags_polling_interval: 60` to keep the previous effective cadence.

--- a/lib/posthog/defaults.rb
+++ b/lib/posthog/defaults.rb
@@ -19,6 +19,7 @@ module PostHog
 
     module FeatureFlags
       FLAG_REQUEST_TIMEOUT_SECONDS = 3
+      POLLING_INTERVAL_SECONDS = 30
       # Number of retries for a flag request after a transient network error.
       # Flag requests are stateless and cause no server-side mutation, so
       # retrying is safe.

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -30,6 +30,7 @@ module PostHog
     include PostHog::Utils
 
     # @param polling_interval [Integer, nil] Seconds between local feature flag definition polls.
+    #   Defaults to {Defaults::FeatureFlags::POLLING_INTERVAL_SECONDS}.
     # @param secret_key [String, nil] Credential used to fetch local evaluation definitions. Accepts either a
     #   Personal API Key (`phx_...`) or a Project Secret API Key (`phs_...`).
     # @param project_api_key [String] Project API key.
@@ -50,7 +51,7 @@ module PostHog
       flag_definition_cache_provider: nil,
       feature_flag_request_max_retries: nil
     )
-      @polling_interval = polling_interval || 30
+      @polling_interval = polling_interval || Defaults::FeatureFlags::POLLING_INTERVAL_SECONDS
       @secret_key = secret_key
       @project_api_key = project_api_key
       @host = host
@@ -72,7 +73,7 @@ module PostHog
 
       @task =
         Concurrent::TimerTask.new(
-          execution_interval: polling_interval
+          execution_interval: @polling_interval
         ) { _load_feature_flags }
 
       # If no secret_key, disable local evaluation & thus polling for definitions

--- a/public_api_snapshot.txt
+++ b/public_api_snapshot.txt
@@ -36,6 +36,7 @@ constant PostHog::Defaults::BackoffPolicy::RANDOMIZATION_FACTOR: Float
 module PostHog::Defaults::FeatureFlags
 constant PostHog::Defaults::FeatureFlags::FLAG_REQUEST_MAX_RETRIES: Integer
 constant PostHog::Defaults::FeatureFlags::FLAG_REQUEST_TIMEOUT_SECONDS: Integer
+constant PostHog::Defaults::FeatureFlags::POLLING_INTERVAL_SECONDS: Integer
 constant PostHog::Defaults::MAX_HASH_SIZE: Integer
 module PostHog::Defaults::Message
 constant PostHog::Defaults::Message::MAX_BYTES: Integer

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -5349,4 +5349,33 @@ module PostHog
       end
     end
   end
+
+  describe 'definitions polling interval' do
+    before do
+      stub_request(
+        :get,
+        'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true'
+      ).to_return(status: 200, body: { flags: [] }.to_json)
+    end
+
+    def timer_task_interval(client)
+      poller = client.instance_variable_get(:@feature_flags_poller)
+      poller.instance_variable_get(:@task).execution_interval
+    end
+
+    it 'defaults to the documented 30 seconds' do
+      client = Client.new(api_key: API_KEY, secret_key: API_KEY, test_mode: true)
+
+      expect(timer_task_interval(client)).to eq(30)
+    end
+
+    it 'uses feature_flags_polling_interval when provided' do
+      client = Client.new(
+        api_key: API_KEY, secret_key: API_KEY, test_mode: true,
+        feature_flags_polling_interval: 15
+      )
+
+      expect(timer_task_interval(client)).to eq(15)
+    end
+  end
 end


### PR DESCRIPTION

## :bulb: Motivation and Context

`feature_flags_polling_interval` is documented as "Defaults to 30" and the poller computes `@polling_interval = polling_interval || 30`, but the value was not actually used, and the 60-second concurrent-ruby was used instead.

This PR fixes the above.

Behavior change worth reviewing: Halves the current effective default. Alternatively, we could update the documented default to 60s.

## :green_heart: How did you test it?

- New "definitions polling interval" specs (2 examples) assert the TimerTask's effective `execution_interval`: 30 when the option is unset, and the configured value when provided. Before the fix, the default case reports 60.
- Full suite: 616 examples, 0 failures. `rubocop` clean. `rake public_api:check` passes with the snapshot regenerated for the one new constant.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

Autonomy: Agent-written, human-directed and reviewed

This bug was found by Claude Code (Fable 5) in a code review on a different PR. All code was written by Claude. My contribution is limited to the "Motivation and Context" paragraph and this paragraph here. I've read the code and I fully understand it.