### PR TITLE
feat: support starts_with and ends_with operators in local evaluation

### DIFF
--- a/.changeset/starts-with-ends-with-operators.md
+++ b/.changeset/starts-with-ends-with-operators.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": minor
+---
+
+Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`, so flags using these operators no longer fall back to remote evaluation.

--- a/.changeset/starts-with-ends-with-operators.md
+++ b/.changeset/starts-with-ends-with-operators.md
@@ -3,3 +3,5 @@
 ---
 
 Support the `starts_with`, `not_starts_with`, `ends_with`, and `not_ends_with` property filter operators in feature flag local evaluation. Matching is case-insensitive and mirrors `icontains`, so flags using these operators no longer fall back to remote evaluation.
+
+Case folding for `icontains`, `not_icontains`, and the four new operators is now ASCII-only (`downcase(:ascii)`), matching the flags service. This is observable for non-ASCII values: `Ä` and `ä` no longer match case-insensitively, which aligns local results with remote evaluation.

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -654,6 +654,14 @@ module PostHog
         override_value.to_s.downcase.include?(value.to_s.downcase)
       when 'not_icontains'
         !override_value.to_s.downcase.include?(value.to_s.downcase)
+      when 'starts_with'
+        override_value.to_s.downcase.start_with?(value.to_s.downcase)
+      when 'not_starts_with'
+        !override_value.to_s.downcase.start_with?(value.to_s.downcase)
+      when 'ends_with'
+        override_value.to_s.downcase.end_with?(value.to_s.downcase)
+      when 'not_ends_with'
+        !override_value.to_s.downcase.end_with?(value.to_s.downcase)
       when 'regex'
         PostHog::Utils.is_valid_regex(value.to_s) && !Regexp.new(value.to_s).match(override_value.to_s).nil?
       when 'not_regex'

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -651,17 +651,17 @@ module PostHog
       when 'is_set'
         property_values.key?(key)
       when 'icontains'
-        override_value.to_s.downcase.include?(value.to_s.downcase)
+        override_value.to_s.downcase(:ascii).include?(value.to_s.downcase(:ascii))
       when 'not_icontains'
-        !override_value.to_s.downcase.include?(value.to_s.downcase)
+        !override_value.to_s.downcase(:ascii).include?(value.to_s.downcase(:ascii))
       when 'starts_with'
-        override_value.to_s.downcase.start_with?(value.to_s.downcase)
+        override_value.to_s.downcase(:ascii).start_with?(value.to_s.downcase(:ascii))
       when 'not_starts_with'
-        !override_value.to_s.downcase.start_with?(value.to_s.downcase)
+        !override_value.to_s.downcase(:ascii).start_with?(value.to_s.downcase(:ascii))
       when 'ends_with'
-        override_value.to_s.downcase.end_with?(value.to_s.downcase)
+        override_value.to_s.downcase(:ascii).end_with?(value.to_s.downcase(:ascii))
       when 'not_ends_with'
-        !override_value.to_s.downcase.end_with?(value.to_s.downcase)
+        !override_value.to_s.downcase(:ascii).end_with?(value.to_s.downcase(:ascii))
       when 'regex'
         PostHog::Utils.is_valid_regex(value.to_s) && !Regexp.new(value.to_s).match(override_value.to_s).nil?
       when 'not_regex'

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -1473,6 +1473,13 @@ module PostHog
       expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'val3' })).to be true
 
       expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'three' })).to be false
+
+      # Case folding is ASCII-only, mirroring the flags service: non-ASCII
+      # characters do not match across case.
+      property_c = { 'key' => 'key', 'value' => 'ä', 'operator' => 'icontains' }
+
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'BÄC' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'bäc' })).to be true
     end
 
     it 'with operator starts_with' do
@@ -1501,6 +1508,13 @@ module PostHog
       expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 123 })).to be false
       expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'val3' })).to be false
 
+      # Case folding is ASCII-only, mirroring the flags service: non-ASCII
+      # characters do not match across case.
+      property_unicode = { 'key' => 'key', 'value' => 'ä', 'operator' => 'starts_with' }
+
+      expect(FeatureFlagsPoller.match_property(property_unicode, { 'key' => 'ÄBC' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_unicode, { 'key' => 'äbc' })).to be true
+
       property_c = { 'key' => 'key', 'value' => 'Val', 'operator' => 'not_starts_with' }
 
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value' })).to be false
@@ -1509,6 +1523,11 @@ module PostHog
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'prevalue' })).to be true
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'Alakazam' })).to be true
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => nil })).to be true
+
+      property_not_unicode = { 'key' => 'key', 'value' => 'ä', 'operator' => 'not_starts_with' }
+
+      expect(FeatureFlagsPoller.match_property(property_not_unicode, { 'key' => 'ÄBC' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_not_unicode, { 'key' => 'äbc' })).to be false
 
       expect do
         FeatureFlagsPoller.match_property(property_c, { 'key2' => 'value' })
@@ -1543,6 +1562,13 @@ module PostHog
       expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 321 })).to be false
       expect(FeatureFlagsPoller.match_property(property_b, { 'key' => '3val' })).to be false
 
+      # Case folding is ASCII-only, mirroring the flags service: non-ASCII
+      # characters do not match across case.
+      property_unicode = { 'key' => 'key', 'value' => 'é', 'operator' => 'ends_with' }
+
+      expect(FeatureFlagsPoller.match_property(property_unicode, { 'key' => 'CAFÉ' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_unicode, { 'key' => 'café' })).to be true
+
       property_c = { 'key' => 'key', 'value' => 'lUe', 'operator' => 'not_ends_with' }
 
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value' })).to be false
@@ -1551,6 +1577,11 @@ module PostHog
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value2' })).to be true
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'Alakazam' })).to be true
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => nil })).to be true
+
+      property_not_unicode = { 'key' => 'key', 'value' => 'é', 'operator' => 'not_ends_with' }
+
+      expect(FeatureFlagsPoller.match_property(property_not_unicode, { 'key' => 'CAFÉ' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_not_unicode, { 'key' => 'café' })).to be false
 
       expect do
         FeatureFlagsPoller.match_property(property_c, { 'key2' => 'value' })

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -1508,6 +1508,12 @@ module PostHog
 
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'prevalue' })).to be true
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'Alakazam' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => nil })).to be true
+
+      expect do
+        FeatureFlagsPoller.match_property(property_c, { 'key2' => 'value' })
+      end.to raise_error(InconclusiveMatchError)
+      expect { FeatureFlagsPoller.match_property(property_c, {}) }.to raise_error(InconclusiveMatchError)
     end
 
     it 'with operator ends_with' do
@@ -1544,6 +1550,12 @@ module PostHog
 
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value2' })).to be true
       expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'Alakazam' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => nil })).to be true
+
+      expect do
+        FeatureFlagsPoller.match_property(property_c, { 'key2' => 'value' })
+      end.to raise_error(InconclusiveMatchError)
+      expect { FeatureFlagsPoller.match_property(property_c, {}) }.to raise_error(InconclusiveMatchError)
     end
 
     it 'with operator regex' do

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -1475,6 +1475,77 @@ module PostHog
       expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'three' })).to be false
     end
 
+    it 'with operator starts_with' do
+      property_a = { 'key' => 'key', 'value' => 'Val', 'operator' => 'starts_with' }
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'VALUE' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'vaLue4' })).to be true
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'prevalue' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'Alakazam' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => nil })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 123 })).to be false
+
+      expect do
+        FeatureFlagsPoller.match_property(property_a, { 'key2' => 'value' })
+      end.to raise_error(InconclusiveMatchError)
+      expect { FeatureFlagsPoller.match_property(property_a, {}) }.to raise_error(InconclusiveMatchError)
+
+      property_b = { 'key' => 'key', 'value' => '3', 'operator' => 'starts_with' }
+
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => '3' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 323 })).to be true
+
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 123 })).to be false
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 'val3' })).to be false
+
+      property_c = { 'key' => 'key', 'value' => 'Val', 'operator' => 'not_starts_with' }
+
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'VALUE' })).to be false
+
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'prevalue' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'Alakazam' })).to be true
+    end
+
+    it 'with operator ends_with' do
+      property_a = { 'key' => 'key', 'value' => 'lUe', 'operator' => 'ends_with' }
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'VALUE' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '343tfvalue' })).to be true
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value2' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'Alakazam' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => nil })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 123 })).to be false
+
+      expect do
+        FeatureFlagsPoller.match_property(property_a, { 'key2' => 'value' })
+      end.to raise_error(InconclusiveMatchError)
+      expect { FeatureFlagsPoller.match_property(property_a, {}) }.to raise_error(InconclusiveMatchError)
+
+      property_b = { 'key' => 'key', 'value' => '3', 'operator' => 'ends_with' }
+
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => '3' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 323 })).to be true
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 13 })).to be true
+
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => 321 })).to be false
+      expect(FeatureFlagsPoller.match_property(property_b, { 'key' => '3val' })).to be false
+
+      property_c = { 'key' => 'key', 'value' => 'lUe', 'operator' => 'not_ends_with' }
+
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'VALUE' })).to be false
+
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'value2' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_c, { 'key' => 'Alakazam' })).to be true
+    end
+
     it 'with operator regex' do
       property_a = { 'key' => 'key', 'value' => '\.com$', 'operator' => 'regex' }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog/posthog#72992 added four case-insensitive property filter operators — `starts_with`, `not_starts_with`, `ends_with`, `not_ends_with` — across HogQL, the flags service, and the UI. The UI surface is gated behind a feature flag until server-side SDKs can evaluate these operators locally; on SDK versions without support, flags using them fall back to remote evaluation.

This adds local evaluation support for the four operators, mirroring `icontains`: both sides are stringified and lowercased, and the `not_` variants are exact negations. Filter values are single strings — server-side validation rejects list values for these operators, matching the flags service behavior.

## :green_heart: How did you test it?

New unit tests mirror the flags service's own test matrix for these operators: case-insensitive anchored matching, mid-string non-matches (`prevalue` does not match `starts_with: "Val"`), numeric stringification (`323` matches `starts_with: "3"`, `123` does not), negation inverses, and missing-key inconclusive behavior.

`bundle exec rspec spec/posthog/feature_flag_spec.rb` passes locally (106 examples), and `bundle exec rubocop` reports no offenses on the changed files.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a changeset file (minor, `posthog-ruby` package)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code as part of rolling out local evaluation for these operators across all server-side SDKs. The implementation deliberately mirrors the existing `icontains` branch in this repo (same string coercion and case folding) and the reference behavior in the Rust flags service (`rust/feature-flags/src/properties/property_matching.rs` in PostHog/posthog). The changeset file was written by hand following the repo's existing format.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
