### PR TITLE
fix(rails): skip duplicate error-reporter capture of web exceptions

### DIFF
--- a/.changeset/skip-duplicate-web-exception-reports.md
+++ b/.changeset/skip-duplicate-web-exception-reports.md
@@ -1,0 +1,5 @@
+---
+"posthog-rails": patch
+---
+
+fix: stop capturing a second, context-free $exception for every unhandled web request exception. ActionDispatch::Executor reports to Rails.error after the response has unwound past CaptureExceptions, so ErrorSubscriber no longer saw it as a web request and re-captured it without $current_url, $request_path or $user_agent

--- a/posthog-rails/lib/posthog/rails.rb
+++ b/posthog-rails/lib/posthog/rails.rb
@@ -21,8 +21,10 @@ module PostHog
     # Thread-local key for tracking web request context
     IN_WEB_REQUEST_KEY = :posthog_in_web_request
     ACTIVE_JOB_CAPTURED_EXCEPTION_IVAR = :@posthog_active_job_exception_captured
+    WEB_CAPTURED_EXCEPTION_IVAR = :@posthog_web_exception_captured
 
     private_constant :ACTIVE_JOB_CAPTURED_EXCEPTION_IVAR
+    private_constant :WEB_CAPTURED_EXCEPTION_IVAR
 
     class << self
       # @return [PostHog::Rails::Configuration] Rails integration configuration.
@@ -82,6 +84,42 @@ module PostHog
       # @return [Boolean]
       def active_job_exception_captured?(exception)
         exception.instance_variable_get(ACTIVE_JOB_CAPTURED_EXCEPTION_IVAR) == true
+      rescue StandardError
+        false
+      end
+
+      # Mark an exception as already captured by the CaptureExceptions middleware.
+      #
+      # ActionDispatch::Executor sits above our middleware and reports unhandled
+      # exceptions to Rails.error *after* the response has unwound back through
+      # CaptureExceptions, so `in_web_request?` is already false by then. The mark
+      # lets ErrorSubscriber recognize the report as a duplicate.
+      #
+      # The whole cause chain is marked because ActionDispatch::ExceptionWrapper
+      # unwraps ActionView::Template::Error to its cause, meaning Rails can report
+      # a different object than the one the middleware captured.
+      # @api private
+      # @param exception [Exception]
+      # @return [void]
+      def mark_web_exception_captured(exception)
+        current = exception
+        seen = {}.compare_by_identity
+
+        while current.is_a?(Exception) && !seen[current]
+          seen[current] = true
+          current.instance_variable_set(WEB_CAPTURED_EXCEPTION_IVAR, true)
+          current = current.cause
+        end
+      rescue StandardError
+        nil
+      end
+
+      # Check whether an exception was already captured by CaptureExceptions.
+      # @api private
+      # @param exception [Exception]
+      # @return [Boolean]
+      def web_exception_captured?(exception)
+        exception.instance_variable_get(WEB_CAPTURED_EXCEPTION_IVAR) == true
       rescue StandardError
         false
       end

--- a/posthog-rails/lib/posthog/rails/capture_exceptions.rb
+++ b/posthog-rails/lib/posthog/rails/capture_exceptions.rb
@@ -60,13 +60,13 @@ module PostHog
         distinct_id = extract_distinct_id(env)
         additional_properties = build_properties(request, env)
 
-        PostHog.capture_exception(
+        captured = PostHog.capture_exception(
           exception,
           distinct_id,
           additional_properties,
           mechanism: { 'type' => 'rails', 'handled' => false }
         )
-        PostHog::Rails.mark_web_exception_captured(exception)
+        PostHog::Rails.mark_web_exception_captured(exception) if captured
       rescue StandardError => e
         PostHog::Logging.logger.error("Failed to capture exception: #{e.message}")
         PostHog::Logging.logger.error("Backtrace: #{e.backtrace&.first(5)&.join("\n")}")

--- a/posthog-rails/lib/posthog/rails/capture_exceptions.rb
+++ b/posthog-rails/lib/posthog/rails/capture_exceptions.rb
@@ -66,6 +66,7 @@ module PostHog
           additional_properties,
           mechanism: { 'type' => 'rails', 'handled' => false }
         )
+        PostHog::Rails.mark_web_exception_captured(exception)
       rescue StandardError => e
         PostHog::Logging.logger.error("Failed to capture exception: #{e.message}")
         PostHog::Logging.logger.error("Backtrace: #{e.backtrace&.first(5)&.join("\n")}")

--- a/posthog-rails/lib/posthog/rails/error_subscriber.rb
+++ b/posthog-rails/lib/posthog/rails/error_subscriber.rb
@@ -23,6 +23,10 @@ module PostHog
         # Skip if in a web request - CaptureExceptions middleware will handle it
         # with richer context (URL, params, controller, etc.)
         return if PostHog::Rails.in_web_request?
+        # ActionDispatch::Executor reports the exception once the response has
+        # unwound past our middleware, so the flag above is already cleared.
+        # CaptureExceptions marks what it captured to catch that late report.
+        return if PostHog::Rails.web_exception_captured?(error)
         return if PostHog::Rails.config&.auto_instrument_active_job &&
                   PostHog::Rails.active_job_exception_captured?(error)
 

--- a/spec/posthog/rails/exception_mechanism_spec.rb
+++ b/spec/posthog/rails/exception_mechanism_spec.rb
@@ -39,6 +39,40 @@ RSpec.describe 'automatic exception capture mechanisms' do
         mechanism: { 'type' => 'rails', 'handled' => false }
       )
     end
+
+    it 'prevents the Rails error subscriber from capturing the same web exception again' do
+      app = ->(_env) { raise StandardError, 'boom' }
+      middleware = described_class.new(app)
+      env = Rack::MockRequest.env_for('/api/test')
+      error = nil
+
+      begin
+        middleware.call(env)
+      rescue StandardError => e
+        error = e
+      end
+
+      # ActionDispatch::Executor sits above this middleware and reports to
+      # Rails.error only after the response has unwound past it, so the
+      # in-web-request flag is already cleared by the time the report lands.
+      expect(PostHog::Rails.in_web_request?).to be(false)
+
+      PostHog::Rails::ErrorSubscriber.new.report(
+        error,
+        handled: false,
+        severity: :error,
+        context: {},
+        source: 'application.action_dispatch'
+      )
+
+      expect(PostHog).to have_received(:capture_exception).once
+      expect(PostHog).to have_received(:capture_exception).with(
+        an_instance_of(StandardError),
+        anything,
+        hash_including('$exception_source' => 'rails'),
+        mechanism: { 'type' => 'rails', 'handled' => false }
+      )
+    end
   end
 
   describe PostHog::Rails::ErrorSubscriber do
@@ -74,6 +108,47 @@ RSpec.describe 'automatic exception capture mechanisms' do
         severity: :error,
         context: {},
         source: 'application.active_support'
+      )
+
+      expect(PostHog).not_to have_received(:capture_exception)
+    end
+
+    it 'skips exceptions already captured by CaptureExceptions' do
+      error = StandardError.new('boom')
+      PostHog::Rails.mark_web_exception_captured(error)
+
+      described_class.new.report(
+        error,
+        handled: false,
+        severity: :error,
+        context: {},
+        source: 'application.action_dispatch'
+      )
+
+      expect(PostHog).not_to have_received(:capture_exception)
+    end
+
+    it 'skips the unwrapped cause of an exception already captured by CaptureExceptions' do
+      wrapped = begin
+        raise 'original'
+      rescue StandardError
+        begin
+          raise 'wrapped'
+        rescue StandardError => e
+          e
+        end
+      end
+
+      PostHog::Rails.mark_web_exception_captured(wrapped)
+
+      # ActionDispatch::ExceptionWrapper unwraps ActionView::Template::Error to
+      # its cause, so Rails reports a different object than the one captured.
+      described_class.new.report(
+        wrapped.cause,
+        handled: false,
+        severity: :error,
+        context: {},
+        source: 'application.action_dispatch'
       )
 
       expect(PostHog).not_to have_received(:capture_exception)

--- a/spec/posthog/rails/exception_mechanism_spec.rb
+++ b/spec/posthog/rails/exception_mechanism_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'automatic exception capture mechanisms' do
     end
 
     it 'prevents the Rails error subscriber from capturing the same web exception again' do
+      allow(PostHog).to receive(:capture_exception).and_return(true)
       app = ->(_env) { raise StandardError, 'boom' }
       middleware = described_class.new(app)
       env = Rack::MockRequest.env_for('/api/test')
@@ -71,6 +72,36 @@ RSpec.describe 'automatic exception capture mechanisms' do
         anything,
         hash_including('$exception_source' => 'rails'),
         mechanism: { 'type' => 'rails', 'handled' => false }
+      )
+    end
+
+    it 'allows the Rails error subscriber to retry when the web capture was not queued' do
+      allow(PostHog).to receive(:capture_exception).and_return(false, true)
+      app = ->(_env) { raise StandardError, 'boom' }
+      middleware = described_class.new(app)
+      env = Rack::MockRequest.env_for('/api/test')
+      error = nil
+
+      begin
+        middleware.call(env)
+      rescue StandardError => e
+        error = e
+      end
+
+      PostHog::Rails::ErrorSubscriber.new.report(
+        error,
+        handled: false,
+        severity: :error,
+        context: {},
+        source: 'application.action_dispatch'
+      )
+
+      expect(PostHog).to have_received(:capture_exception).twice
+      expect(PostHog).to have_received(:capture_exception).with(
+        error,
+        anything,
+        hash_including('$exception_source' => 'application.action_dispatch'),
+        mechanism: { 'type' => 'rails_error_reporter', 'handled' => false }
       )
     end
   end


### PR DESCRIPTION
## :bulb: Motivation and Context

In production (or any environment with reloading off), **every unhandled web request exception is captured twice** — and the second copy carries none of the request properties.

`ActionDispatch::Executor` sits above the PostHog middleware in the stack:

```
ActionDispatch::Executor            ← reports to Rails.error
  …
  PostHog::Rails::RequestContext    ← request context lives only inside here
    ActionDispatch::ShowExceptions
      PostHog::Rails::CaptureExceptions
```

`ShowExceptions` renders the error response and sets `action_dispatch.report_exception`. On the way back out, `Executor` reports the exception to `Rails.error` with `source: "application.action_dispatch"` ([`executor.rb#L22-L25`](https://github.com/rails/rails/blob/v8.1.3.1/actionpack/lib/action_dispatch/middleware/executor.rb#L22-L25)) — by which point `CaptureExceptions`' `ensure` has already cleared `in_web_request?` and `RequestContext`'s `ensure` has torn down the context. `ErrorSubscriber` therefore doesn't recognize the report as a duplicate and captures the exception again, with no `$current_url`, `$request_path`, `$user_agent` or `$ip`.

Development masks this: `ActionDispatch::Reloader` (an `Executor` subclass) sits *inside* our middleware and reports first, so the existing `in_web_request?` guard does its job. Rails omits `Reloader` when reloading is off, so the bug only appears in production-like environments.

Reproduced on a Rails 8.1.3.1 app. A single `NoMethodError` in a controller produced:

| mechanism | `$exception_source` | `$current_url` |
| --- | --- | --- |
| `rails` | `rails` | `https://…/donate` |
| `rails_error_reporter` | `application.action_dispatch` | `nil` |

Both events share a fingerprint, so they group into one issue whose events are half-populated — which is how this was noticed: opening an issue in the UI often shows the context-free copy.

### Wrapped exceptions

`ActionDispatch::ExceptionWrapper#unwrapped_exception` unwraps `ActionView::Template::Error` to its `cause`, so for anything raised inside a view Rails reports a **different object** than the middleware captured — under a different exception type, which lands in a **separate issue** rather than merely polluting an existing one:

| mechanism | type | `$current_url` |
| --- | --- | --- |
| `rails` | `ActionView::Template::Error` | `https://…/donate` |
| `rails_error_reporter` | `NoMethodError` | `nil` |

So marking only the top-level object isn't enough — the fix marks the whole `cause` chain.

## :green_heart: How did you test it?

**Unit specs** (`spec/posthog/rails/exception_mechanism_spec.rb`, 3 added). I confirmed all three fail against `main` and pass with the fix:

```
1) …CaptureExceptions prevents the Rails error subscriber from capturing the same web exception again
2) …ErrorSubscriber skips exceptions already captured by CaptureExceptions
3) …ErrorSubscriber skips the unwrapped cause of an exception already captured by CaptureExceptions
```

They mirror the existing `prevents Rails error subscriber from capturing the same job exception again` spec.

**End-to-end in a real Rails 8.1.3.1 app.** Specs alone can't prove this one, since the bug is entirely about middleware ordering, so I drove real requests through the app's actual built middleware stack, reshaped to match production (`consider_all_requests_local = false`, `ActionDispatch::Reloader` removed) and intercepted `PostHog::Client#enqueue` so nothing was sent over the network. I swapped only the three patched files into the installed 3.17.1 gem, so the before/after differs by exactly this change:

| scenario | before | after |
| --- | --- | --- |
| `NoMethodError` in a controller action | 2 events (one with no request properties) | 1 event, `$current_url` / `$request_path` / `$controller` / `$action` / `$user_agent` / `$ip` all present |
| `NoMethodError` raised inside a template | 2 events, in 2 different issues | 1 event, `ActionView::Template::Error`, properties present |

I also confirmed successful (200) requests still enqueue no events, and that the dev stack (with `Reloader` present) is unchanged.

**CI-aligned checks:** `bundle exec rspec` passes (540 examples, 0 failures) and `bundle exec rubocop` reports no new offenses. Two caveats, both reproduced identically on unmodified `main` in my environment and unrelated to this change: `spec/posthog/feature_flag_spec.rb` fails to load because `timecop` isn't installed by `bundle install` despite being in the Gemfile, and `rake public_api:check` reports a spurious `PostHog::Rails` diff. I excluded that one spec file to get the 540-example run. `public_api_snapshot.txt` is intentionally unchanged — both new methods are `@api private`, which the generator filters out.

### Edge cases considered

- **Marking on failure.** The mark is set after `PostHog.capture_exception` returns, inside the existing `rescue`, so a failed capture doesn't suppress the error-reporter fallback.
- **Cause-chain cycles.** The walk uses an identity-keyed `Hash`, which also avoids calling `hash`/`eql?` on user exception objects.
- **Frozen or exotic exceptions.** `instance_variable_set` is wrapped in `rescue StandardError` like the existing ActiveJob helper, so marking degrades to today's behavior rather than raising.
- **Exceptions raised above `CaptureExceptions`** (e.g. inside `ShowExceptions`) are unmarked and still captured by `ErrorSubscriber` — unchanged, and correct.
- **Non-web reports** (jobs, `Rails.error.report` from app code) are untouched; the mark is only ever set by the middleware.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I hit this in my own app — server-side exceptions were arriving in PostHog with no URL — and used Claude Code (Opus 5) to help track down why and to draft the fix. No shareable session link.

The investigation was empirical rather than by inspection: instrumenting `ActiveSupport::ErrorReporter#report` to dump call sites is what revealed there are two `Executor` instances in a dev stack (the second being `Reloader`), which explained why the existing `in_web_request?` guard works in development but not production. I checked the diagnosis by reproducing both event shapes against the real middleware stack before writing any code.

On approach: I first fixed it in my own app by hoisting `RequestContext` and `CaptureExceptions` above `ActionDispatch::Executor` via `config.middleware.move_before`. That works, but it seemed like the wrong thing to push upstream — it moves user code (notably the `current_user` resolver used when `capture_user_context` is enabled) outside the Rails executor, so `current_user` would run without a checked-out Active Record connection. Marking the captured exception is narrower and follows the precedent already set for ActiveJob in #217. The cause-chain traversal was added after testing the template-error case and finding the single-object mark didn't hold.

_DRI: @hasghari (PR author). The template asks for the driver to be set as assignee, but external contributors can't self-assign — please assign me if that matters for your triage._
