### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    reviewers:
+      - "PostHog/team-client-libraries"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    cooldown:
-      default-days: 7
+  - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: weekly
-    reviewers:
-      - "PostHog/team-client-libraries"
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## :bulb: Motivation and Context

This repository uses Bundler for the root `Gemfile` and gemspec, npm for the root release-tooling `package.json`, and GitHub Actions for workflow dependencies. This adds Dependabot coverage for all three ecosystems from the repository root, with weekly updates and a seven-day cooldown for each.

Reviewer assignment is intentionally left to the existing `.github/CODEOWNERS` rule, which assigns repository changes to `@PostHog/team-client-libraries`; the Dependabot configuration does not duplicate a `reviewers` field.

## :green_heart: How did you test it?

- Parsed `.github/dependabot.yml` with Ruby's YAML parser and asserted the exact ecosystem order (`bundler`, `npm`, `github-actions`), root directory, weekly interval, seven-day cooldown, version, and absence of additional fields such as reviewers.
- Ran `git diff --check`.
- GitHub's native `.github/dependabot.yml` validation passed.
- All 20 PR checks completed successfully, including RSpec on Ruby 3.2–3.4, RuboCop, SDK compliance, CodeQL, Semgrep, and Wiz scans.
- Ran Pi branch autoreview against `origin/main` for `de0208a182cb285c96c4412d2431d0516d2d8cc8`; it reported no accepted or actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi worker agent updated and validated the configuration. Pi autoreview reviewed the committed branch against `origin/main`. The change is limited to the requested Dependabot configuration.
