### PR TITLE
chore(deps-dev): bump rubocop from 1.75.8 to 1.88.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,21 @@ Naming/FileName:
   Exclude:
     - "posthog-rails/lib/posthog-rails.rb"
 
+Naming/PredicateMethod:
+  AllowedMethods:
+    - call
+    - check
+    - condition_match
+    - enqueue
+    - flush
+    - match_regular_property_group
+
+Style/OneClassPerFile:
+  Exclude:
+    - "sdk_compliance_adapter/adapter.rb"
+    - "spec/**/*"
+    - "test/**/*"
+
 # Modern Ruby 3.0+ specific cops
 Style/HashTransformKeys:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development, :test do
   gem 'railties', '~> 7.1'
   gem 'rake', '~> 13.4.2'
   gem 'rspec', '~> 3.13'
-  gem 'rubocop', '~> 1.75.6'
+  gem 'rubocop', '~> 1.88.2'
   gem 'timecop'
   gem 'tzinfo', '~> 2.0'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,8 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.9)
-    language_server-protocol (3.17.0.5)
+    json (2.21.2)
+    language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.2)
@@ -102,8 +102,8 @@ GEM
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     ostruct (0.6.3)
-    parallel (1.27.0)
-    parser (3.3.11.1)
+    parallel (1.28.0)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     pp (0.6.4)
@@ -155,7 +155,7 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    regexp_parser (2.11.3)
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
@@ -172,18 +172,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.75.8)
+    rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.44.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     ruby-progressbar (1.13.0)
@@ -237,7 +237,7 @@ DEPENDENCIES
   railties (~> 7.1)
   rake (~> 13.4.2)
   rspec (~> 3.13)
-  rubocop (~> 1.75.6)
+  rubocop (~> 1.88.2)
   timecop
   tzinfo (~> 2.0)
   webmock
@@ -270,8 +270,8 @@ CHECKSUMS
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
-  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
-  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
@@ -286,8 +286,8 @@ CHECKSUMS
   nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
   oj (3.17.4) sha256=733fe3bcb7a5d985bd2e943620b7bea1bffb2809318af7021c841b833a6858e1
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
-  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
-  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
   posthog-ruby (3.23.0)
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettier (4.0.4) sha256=713110c77675de802806b4e09b4b7783e497689db3e8a991f812aa78f4835bc5
@@ -308,7 +308,7 @@ CHECKSUMS
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
-  regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
@@ -316,8 +316,8 @@ CHECKSUMS
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
-  rubocop (1.75.8) sha256=c80ab4286c5dcfc49d7ad1787cdba5569b63b58c96ee7afde4ec47a9c8a85be9
-  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -472,7 +472,7 @@ module PostHog
     # @param send_feature_flag_events [Boolean] Whether to capture `$feature_flag_called` for this access.
     # @return [Boolean, nil] Whether the flag is enabled, or nil when the flag could not be evaluated.
     # TODO: In future version, rename to `feature_flag_enabled?`
-    def is_feature_enabled( # rubocop:disable Naming/PredicateName
+    def is_feature_enabled( # rubocop:disable Naming/PredicatePrefix
       flag_key,
       distinct_id,
       groups: {},
@@ -712,8 +712,8 @@ module PostHog
               enabled: ff.enabled ? true : false,
               variant: ff.variant,
               payload: FeatureFlagResult.parse_payload(ff.payload),
-              id: metadata ? metadata.id : nil,
-              version: metadata ? metadata.version : nil,
+              id: metadata&.id,
+              version: metadata&.version,
               reason: reason ? (reason.description || reason.code) : nil,
               locally_evaluated: false,
               has_experiment: metadata&.has_experiment

--- a/lib/posthog/noop_worker.rb
+++ b/lib/posthog/noop_worker.rb
@@ -17,7 +17,7 @@ module PostHog
 
     # @return [Boolean]
     # TODO: Rename to `requesting?` in future version
-    def is_requesting? # rubocop:disable Naming/PredicateName
+    def is_requesting? # rubocop:disable Naming/PredicatePrefix
       false
     end
 

--- a/lib/posthog/send_worker.rb
+++ b/lib/posthog/send_worker.rb
@@ -113,7 +113,7 @@ module PostHog
     #
     # @return [Boolean] Whether the worker has outstanding requests.
     # TODO: Rename to `requesting?` in future version
-    def is_requesting? # rubocop:disable Naming/PredicateName
+    def is_requesting? # rubocop:disable Naming/PredicatePrefix
       ensure_current_process!
 
       @lock.synchronize { !@batch.empty? }

--- a/lib/posthog/utils.rb
+++ b/lib/posthog/utils.rb
@@ -111,7 +111,7 @@ module PostHog
     UTC_OFFSET_WITHOUT_COLON = UTC_OFFSET_WITH_COLON.sub(':', '')
 
     # TODO: Rename to `valid_regex?` in future version
-    def is_valid_regex(regex) # rubocop:disable Naming/PredicateName
+    def is_valid_regex(regex) # rubocop:disable Naming/PredicatePrefix
       Regexp.new(regex)
       true
     rescue RegexpError


### PR DESCRIPTION
## :bulb: Motivation and Context

Recreates #240, which updated RuboCop but failed after 1.88.2 enabled additional cops and renamed an existing predicate cop.

This upgrades the development-only linter, configures the new naming/file-layout checks for established repository conventions, and applies semantically neutral cleanup. Runtime behavior and the public API are unchanged.

## :green_heart: How did you test it?

- `bundle exec rubocop` — 83 files, no offenses
- `bundle exec rspec` — 656 examples, 0 failures
- `bundle exec rake public_api:check`
- Built both `posthog-ruby` and `posthog-rails` gems

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented and independently reviewed with Pi's `worker` and `reviewer` subagents. The session remained local and is not publicly shared. The lint fixes were limited to established cop exceptions, renamed inline directives, and reviewed nil-safe cleanup; behavioral changes and public API changes were explicitly excluded.
