### PR TITLE
chore: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,27 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      bundler-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      release-tooling:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot currently opens a separate pull request for each eligible update. Grouping updates by ecosystem reduces pull request noise while keeping Bundler, release tooling, and GitHub Actions changes separate.

This change adds wildcard groups for all three configured ecosystems:

- `bundler-dependencies` for Bundler updates
- `release-tooling` for npm updates
- `github-actions` for GitHub Actions updates

## :green_heart: How did you test it?

Parsed `.github/dependabot.yml` with Ruby's YAML parser and verified that each ecosystem has the requested wildcard group.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The Pi agent implemented the requested Dependabot grouping and validated the YAML structure. The diff is limited to repository administration, so automated code review was skipped. A human must review this pull request before merge.
