### PR TITLE
fix: normalize SDK timestamps to UTC

### DIFF
--- a/.changeset/calm-clocks-align.md
+++ b/.changeset/calm-clocks-align.md
@@ -1,5 +1,6 @@
 ---
 "posthog-ruby": patch
+"posthog-rails": patch
 ---
 
 Normalize event timestamps to the equivalent UTC instant before serialization.

--- a/.changeset/calm-clocks-align.md
+++ b/.changeset/calm-clocks-align.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": patch
+---
+
+Normalize event timestamps to the equivalent UTC instant before serialization.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -262,7 +262,8 @@ module PostHog
     #     invalid and `:message_id` is a valid UUID, it is sent as `uuid` for backwards compatibility.
     #     If neither value is valid, the SDK generates a `uuid`. SDK metadata is sent as `$lib` and
     #     `$lib_version` properties.
-    #   @option attrs [Time] :timestamp When the event occurred (optional)
+    #   @option attrs [Time] :timestamp When the event occurred (optional). UTC is preferred;
+    #     non-UTC values are converted to the equivalent UTC instant before serialization.
     #   @option attrs [String] :distinct_id The ID for this user in your database
 
     # Captures an event

--- a/lib/posthog/field_parser.rb
+++ b/lib/posthog/field_parser.rb
@@ -150,7 +150,7 @@ module PostHog
         properties['$is_server'] = true if is_server
 
         parsed = {
-          timestamp: datetime_in_iso8601(timestamp),
+          timestamp: time_in_iso8601(timestamp.getutc),
           distinct_id: distinct_id,
           properties: properties
         }

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -400,6 +400,51 @@ module PostHog
         expect(Time.parse(client.dequeue_last_message[:timestamp])).to eq(time)
       end
 
+      it 'converts a non-UTC timestamp override to the equivalent UTC wire value' do
+        wire_payload = nil
+        stub_request(:post, 'https://us.i.posthog.com/batch/')
+          .with do |request|
+            wire_payload = JSON.parse(Zlib.gunzip(request.body))
+            true
+          end
+          .to_return(status: 200, body: '{}')
+        sync_client = Client.new(api_key: API_KEY, sync_mode: true)
+
+        sync_client.capture(
+          event: 'testing UTC timestamp normalization',
+          distinct_id: 'joe',
+          timestamp: Time.new(2024, 7, 16, 13, 30, Rational(123, 1000), '+09:30')
+        )
+
+        expect(wire_payload['batch'].first['timestamp']).to eq('2024-07-16T04:00:00.123Z')
+      ensure
+        sync_client&.shutdown
+      end
+
+      it 'emits an exact UTC default timestamp when the process timezone is non-UTC' do
+        previous_tz = ENV.fetch('TZ', nil)
+        ENV['TZ'] = 'America/Los_Angeles'
+        allow(Time).to receive(:new).and_return(Time.local(2024, 1, 2, 3, 4, 5, 123_000))
+
+        client.capture(event: 'testing the default timestamp', distinct_id: 'joe')
+
+        expect(client.dequeue_last_message[:timestamp]).to eq('2024-01-02T11:04:05.123Z')
+      ensure
+        ENV['TZ'] = previous_tz
+      end
+
+      it 'does not normalize arbitrary Time properties to UTC' do
+        property_time = Time.new(2024, 7, 16, 13, 30, Rational(123, 1000), '+09:30')
+
+        client.capture(
+          event: 'testing a Time property',
+          distinct_id: 'joe',
+          properties: { caller_time: property_time }
+        )
+
+        expect(client.dequeue_last_message[:properties][:caller_time]).to eq('2024-07-16T13:30:00.123+09:30')
+      end
+
       it 'does not error with the required options' do
         expect do
           client.capture Queued::CAPTURE
@@ -2034,6 +2079,14 @@ module PostHog
 
         expect(message[:properties]['user_agent']).to eq('Test Agent')
         expect(message[:properties]['request_id']).to eq('req-123')
+      end
+
+      it 'emits the SDK-generated exception timestamp in UTC' do
+        allow(Time).to receive(:now).and_return(Time.new(2024, 7, 16, 13, 30, Rational(123, 1000), '+09:30'))
+
+        client.capture_exception(StandardError.new('Test exception'), 'user-123')
+
+        expect(client.dequeue_last_message[:timestamp]).to eq('2024-07-16T04:00:00.123Z')
       end
 
       it 'captures the full cause chain outermost-first' do


### PR DESCRIPTION
## :bulb: Motivation and Context

Event timestamps currently keep the offset from the supplied `Time` value or the process timezone. This can send values such as `2024-07-16T13:30:00.123+09:30` instead of the SDK's expected UTC wire format.

This change converts every event timestamp to the equivalent UTC instant before ISO 8601 serialization. For example, `2024-07-16 13:30:00.123 +09:30` is sent as `2024-07-16T04:00:00.123Z`. The conversion applies to explicit timestamp overrides, SDK-generated default timestamps, and exception capture timestamps. Arbitrary `Time` values inside event properties keep their original offsets.

## :green_heart: How did you test it?

- Added regression coverage that inspects the compressed batch request and verifies the exact UTC wire value for a non-UTC timestamp override.
- Added coverage for an SDK-generated timestamp while the process timezone is `America/Los_Angeles`.
- Added coverage that confirms arbitrary `Time` properties are not normalized.
- Added coverage for the SDK-generated exception timestamp.
- Ran `bundle exec rspec` with 660 examples and no failures.
- Ran `bundle exec rubocop` with 83 files and no offenses.
- Ran `bundle exec rake public_api:check` successfully.
- Ran `pnpm changeset status` successfully.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent (`worker`, GPT-5.6 Sol) prepared the existing changes for review and opened this PR. The local Pi session has no shareable URL. The agent added the required patch changeset, ran the repository checks, and ran the committed-HEAD autoreview against `origin/main`. No review findings required code changes.
