### PR TITLE
fix: treat 2xx responses as successful

### DIFF
--- a/.changeset/tidy-2xx-responses.md
+++ b/.changeset/tidy-2xx-responses.md
@@ -1,0 +1,5 @@
+---
+'posthog-ruby': patch
+---
+
+Treat all successful HTTP responses as successful, including responses without a body.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -1179,7 +1179,7 @@ module PostHog
 
       @sync_lock.synchronize do
         res = @transport.send(@api_key, batch)
-        @on_error.call(res.status, res.error) unless res.status == 200
+        @on_error.call(res.status, res.error) unless res.status.between?(200, 299)
       end
     end
 

--- a/lib/posthog/send_worker.rb
+++ b/lib/posthog/send_worker.rb
@@ -154,7 +154,7 @@ module PostHog
 
     def send_batch
       res = @transport.send @api_key, @batch
-      handle_error(res.status, res.error) unless res.status == 200
+      handle_error(res.status, res.error) unless res.status.between?(200, 299)
     end
 
     def consume_message_from_queue!

--- a/lib/posthog/transport.rb
+++ b/lib/posthog/transport.rb
@@ -73,7 +73,7 @@ module PostHog
           status_code, body = send_request(api_key, batch)
           error =
             begin
-              JSON.parse(body)['error']
+              body && JSON.parse(body)['error']
             rescue JSON::ParserError
               body
             end

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -273,6 +273,20 @@ module PostHog
         expect(error_status).to eq(400)
       end
 
+      [201, 202, 204].each do |status|
+        it "does not call on_error for a #{status} response" do
+          on_error = proc {}
+          expect(on_error).to_not receive(:call)
+
+          allow_any_instance_of(PostHog::Transport).to(
+            receive(:send).and_return(PostHog::Response.new(status))
+          )
+
+          sync_client = Client.new(api_key: API_KEY, sync_mode: true, on_error: on_error)
+          sync_client.capture(Queued::CAPTURE)
+        end
+      end
+
       it 'flush does not attempt to run a worker' do
         sync_client = Client.new(api_key: API_KEY, sync_mode: true)
         expect(sync_client).not_to receive(:ensure_worker_running)

--- a/spec/posthog/send_worker_spec.rb
+++ b/spec/posthog/send_worker_spec.rb
@@ -168,6 +168,23 @@ module PostHog
         expect(queue).to be_empty
       end
 
+      [201, 202, 204].each do |status|
+        it "does not call on_error for a #{status} response" do
+          allow_any_instance_of(PostHog::Transport).to(
+            receive(:send).and_return(PostHog::Response.new(status))
+          )
+          on_error = proc {}
+          expect(on_error).to_not receive(:call)
+
+          queue = Queue.new
+          queue << Requested::CAPTURE
+          worker = described_class.new(queue, 'testsecret', on_error: on_error, flush_interval_seconds: 0)
+          run_worker_until_idle(worker, queue)
+
+          expect(queue).to be_empty
+        end
+      end
+
       it 'calls on_error for bad json' do
         bad_message = Requested::CAPTURE.dup
         def bad_message.to_json(*_args)

--- a/spec/posthog/transport_spec.rb
+++ b/spec/posthog/transport_spec.rb
@@ -219,12 +219,25 @@ module PostHog
 
         context 'request is successful' do
           let(:status_code) { 201 }
+
           it 'returns a response code' do
             expect(subject.send(api_key, batch).status).to eq(status_code)
           end
 
           it 'returns a nil error' do
             expect(subject.send(api_key, batch).error).to be_nil
+          end
+        end
+
+        context 'request returns no content' do
+          let(:response) { Net::HTTPNoContent.new(http_version, 204, 'No Content') }
+          let(:response_body) { nil }
+
+          it 'returns a successful response' do
+            result = subject.send(api_key, batch)
+
+            expect(result.status).to eq(204)
+            expect(result.error).to be_nil
           end
         end
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Only `200` responses were considered successful, so other successful responses such as `201`, `202`, and `204` triggered `on_error`.

This updates both the sync client and background worker to accept any 2xx response.

It fixes issue https://github.com/PostHog/posthog-ruby/issues/187

## :green_heart: How did you test it?

Added specs covering `201`, `202`, and `204` responses in both code paths.

- Full test suite: 670 examples, 0 failures
- RuboCop: no offenses
- `rake public_api:check`: passed

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used GPT-5.6 in Codex to help implement and test the change. I reviewed the final code.