### PR TITLE
fix: Drop events when before_send callbacks raise

### DIFF
--- a/.changeset/quiet-hooks-close.md
+++ b/.changeset/quiet-hooks-close.md
@@ -1,0 +1,5 @@
+---
+'posthog-ruby': patch
+---
+
+Drop events when before_send callbacks raise exceptions.

--- a/.changeset/quiet-hooks-close.md
+++ b/.changeset/quiet-hooks-close.md
@@ -1,5 +1,6 @@
 ---
 'posthog-ruby': patch
+'posthog-rails': patch
 ---
 
 Drop events when before_send callbacks raise exceptions.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -1099,8 +1099,8 @@ module PostHog
 
         processed_action
       rescue StandardError => e
-        logger.error("Error in beforeSend function - using original event: #{e.message}")
-        action
+        logger.error("Error in beforeSend function - dropping event: #{e.message}")
+        nil
       end
     end
 

--- a/posthog-rails/lib/posthog/rails/logs/appender.rb
+++ b/posthog-rails/lib/posthog/rails/logs/appender.rb
@@ -166,10 +166,9 @@ module PostHog
         # before_send that drops noisy logs must not starve the legitimate
         # records behind them.
         #
-        # Unlike the events before_send (which sends the original event when the
-        # callback raises), a failing callback drops the record: the likeliest
-        # use is PII scrubbing, where shipping the unscrubbed original is worse
-        # than losing the line.
+        # A failing callback drops the record: the likeliest use is PII
+        # scrubbing, where shipping the unscrubbed original is worse than losing
+        # the line.
         def apply_before_send(record)
           return record unless @before_send
 

--- a/spec/posthog/client_spec.rb
+++ b/spec/posthog/client_spec.rb
@@ -1275,24 +1275,50 @@ module PostHog
         expect(logger).to have_received(:warn).with(warning_message)
       end
 
-      it 'does not explode if before_send throws an error' do
-        client = Client.new(api_key: API_KEY, test_mode: true, before_send: lambda { |_message|
+      it 'drops queued events when before_send mutates and then raises without raising to the caller' do
+        client = Client.new(api_key: API_KEY, test_mode: true, before_send: lambda { |message|
+          message[:event] = 'mutated_event'
           raise 'e by gum'
         })
+        queue = client.instance_variable_get(:@queue)
+        allow(queue).to receive(:<<)
 
-        allow(logger).to receive(:error)
+        result = nil
+        expect do
+          result = client.capture(
+            {
+              distinct_id: 'distinct_id',
+              event: 'test_event'
+            }
+          )
+        end.not_to raise_error
 
-        client.capture(
-          {
-            distinct_id: 'distinct_id',
-            event: 'test_event'
-          }
-        )
+        expect(result).to be(false)
+        expect(queue).not_to have_received(:<<)
+        expect(client.queued_messages).to eq(0)
+        expect(logger).to have_received(:error).with('Error in beforeSend function - dropping event: e by gum')
+      end
 
-        expect(logger).to have_received(:error).with('Error in beforeSend function - using original event: e by gum')
+      it 'drops synchronous events when before_send mutates and then raises without raising to the caller' do
+        client = Client.new(api_key: API_KEY, sync_mode: true, before_send: lambda { |message|
+          message[:event] = 'mutated_event'
+          raise 'e by gum'
+        })
+        expect(client).not_to receive(:send_sync)
 
-        last_message = client.dequeue_last_message
-        expect(last_message[:event]).to eq('test_event')
+        result = nil
+        expect do
+          result = client.capture(
+            {
+              distinct_id: 'distinct_id',
+              event: 'test_event'
+            }
+          )
+        end.not_to raise_error
+
+        expect(result).to be(false)
+        expect(client.queued_messages).to eq(0)
+        expect(logger).to have_received(:error).with('Error in beforeSend function - dropping event: e by gum')
       end
     end
 


### PR DESCRIPTION
## :bulb: Motivation and Context

A `before_send` callback that raised an exception caused the SDK to continue with the original event. This could send data that the callback intended to redact or reject.

This change logs the callback error and drops the event instead. Both queued and synchronous capture paths return without enqueueing or sending the event, including when the callback mutates it before raising. The Rails log callback documentation is updated to match, and the changeset includes patch releases for both `posthog-ruby` and `posthog-rails`.

## :green_heart: How did you test it?

- `bundle exec rspec spec/posthog/client_spec.rb` - 127 examples passed
- `bundle exec rubocop lib/posthog/client.rb posthog-rails/lib/posthog/rails/logs/appender.rb spec/posthog/client_spec.rb`
- `bundle exec rake public_api:check`
- `pnpm changeset status`
- `git diff --check`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent helped audit the existing behavior, update the implementation and tests, run validation, and prepare this PR. The chosen behavior follows the cross-SDK contract: callback failures are contained and the event is dropped rather than sent without the callback's intended processing.
