### PR TITLE
ci: update shared workflow pins

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -14,7 +14,7 @@ jobs:
         # Dependabot and forked PRs cannot access the app credentials required by
         # the reusable project-board workflow.
         if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@95c20087fda2dc10fbbbcc3f1ef32b7bae779339
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@5ba5d24966f2c416ca792654638e4ce6f19f545b
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     name: Notify Slack - Approval Needed
     needs: check-changesets
     if: needs.check-changesets.outputs.has-changesets == 'true'
-    uses: posthog/.github/.github/workflows/notify-approval-needed.yml@5fc4680761e8ac29a61b212756230eba0e276d8c
+    uses: posthog/.github/.github/workflows/notify-approval-needed.yml@5ba5d24966f2c416ca792654638e4ce6f19f545b
     with:
       slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
       slack_user_group_id: ${{ vars.GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID }}


### PR DESCRIPTION
## :bulb: Motivation and Context

The shared project-board and release-approval workflows have changed since the commits pinned by this repository. Keeping these references current applies the latest shared workflow behavior while retaining immutable full-SHA pins.

## :green_heart: How did you test it?

Compared the exact Git blob for each referenced workflow at the old pin and at `PostHog/.github@5ba5d24966f2c416ca792654638e4ce6f19f545b`. Confirmed that only workflows with different content were updated, then ran `git diff --check`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi worker agent made this repository-administration update. It compared workflow file content rather than commit age and left the unchanged semantic-title workflow pin alone.
