### PR TITLE
fix(flags): handle empty evaluation key scopes

### DIFF
--- a/.changeset/empty-scopes-return.md
+++ b/.changeset/empty-scopes-return.md
@@ -1,0 +1,5 @@
+---
+'posthog-ruby': patch
+---
+
+Return an empty feature flag snapshot without evaluation when `flag_keys` is empty.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -607,10 +607,9 @@ module PostHog
     # @param [Boolean] only_evaluate_locally Skip the remote /flags call entirely
     # @param [Boolean, nil] disable_geoip When true, disables GeoIP lookup for remote evaluation and stamps captured
     #   access events.
-    # @param [Array<String, Symbol>] flag_keys When set, scopes the underlying /flags
-    #   request to only these flag keys (sent as `flag_keys_to_evaluate`).
-    #   Distinct from {FeatureFlagEvaluations#only}, which filters the
-    #   already-fetched snapshot in memory.
+    # @param [Array<String, Symbol>, nil] flag_keys When set, scopes evaluation to only these flag keys.
+    #   An empty array returns an empty snapshot without evaluating flags; +nil+ evaluates all flags.
+    #   Distinct from {FeatureFlagEvaluations#only}, which filters the already-fetched snapshot in memory.
     # @return [PostHog::FeatureFlagEvaluations]
     def evaluate_flags(
       distinct_id,
@@ -628,6 +627,12 @@ module PostHog
       end
 
       return FeatureFlagEvaluations.new(host: host, distinct_id: distinct_id, flags: {}, groups: groups) if @disabled
+
+      if flag_keys && flag_keys.empty?
+        return FeatureFlagEvaluations.new(
+          host: host, distinct_id: distinct_id, flags: {}, groups: groups, disable_geoip: disable_geoip
+        )
+      end
 
       person_properties, group_properties = add_local_person_and_group_properties(
         groups, person_properties, group_properties

--- a/spec/posthog/feature_flag_evaluations_spec.rb
+++ b/spec/posthog/feature_flag_evaluations_spec.rb
@@ -182,6 +182,34 @@ module PostHog
         )
       end
 
+      it 'returns an empty snapshot for empty flag_keys without poller or remote work' do
+        stub_flags(flags_response)
+        poller = client.instance_variable_get(:@feature_flags_poller)
+        expect(poller).not_to receive(:load_feature_flags)
+        expect(poller).not_to receive(:feature_flags_by_key)
+        expect(poller).not_to receive(:_compute_flag_locally)
+        expect(poller).not_to receive(:get_flags)
+
+        snapshot = client.evaluate_flags('user-1', flag_keys: [])
+
+        expect(snapshot).to be_a(FeatureFlagEvaluations)
+        expect(snapshot.keys).to eq([])
+        expect(snapshot.enabled?('missing-flag')).to be(false)
+        expect(snapshot.get_flag('missing-flag')).to be_nil
+
+        events = drain_messages(client).select { |message| message[:event] == '$feature_flag_called' }
+        expect(events.length).to eq(1)
+        expect(events.first[:properties]['$feature_flag_error']).to eq('flag_missing')
+        expect(WebMock).not_to have_requested(:post, FLAGS_ENDPOINT)
+      end
+
+      it 'treats nil flag_keys as an unscoped evaluation' do
+        stub_flags(flags_response)
+        snapshot = client.evaluate_flags('user-1', flag_keys: nil)
+        expect(snapshot.keys).to match_array(%w[variant-flag boolean-flag disabled-flag])
+        expect(WebMock).to have_requested(:post, FLAGS_ENDPOINT).once
+      end
+
       it 'returns a usable empty snapshot for empty distinct_id and does not call /flags' do
         stub_flags(flags_response)
         snapshot = client.evaluate_flags('')


### PR DESCRIPTION
## :bulb: Motivation and Context

[`sdk-specs#47`](https://github.com/PostHog/sdk-specs/pull/47) defines how SDKs should distinguish an empty feature flag evaluation scope from an omitted scope. The Ruby SDK previously treated `flag_keys: []` like no scope and evaluated every available flag.

This change makes the three cases explicit:

- When `flag_keys` is omitted or `nil`, evaluation remains unscoped and all available flags are evaluated.
- When `flag_keys` is an empty array, `evaluate_flags` returns an empty snapshot without loading local flag definitions or calling `/flags`.
- When `flag_keys` contains keys, the existing scoped behavior remains unchanged and only those keys are requested and evaluated.

The returned empty snapshot remains usable. Accessing a missing key returns the normal missing-flag result and records the normal access event.

## :green_heart: How did you test it?

- `BUNDLE_PATH=/tmp/posthog-ruby-bundle bundle exec rspec spec/posthog/feature_flag_evaluations_spec.rb` - passed with 48 examples and 0 failures.
- `BUNDLE_PATH=/tmp/posthog-ruby-bundle bundle exec rubocop` - passed with 84 files inspected and no offenses.
- `BUNDLE_PATH=/tmp/posthog-ruby-bundle bundle exec ruby -c lib/posthog/client.rb && BUNDLE_PATH=/tmp/posthog-ruby-bundle bundle exec ruby -c spec/posthog/feature_flag_evaluations_spec.rb` - both syntax checks passed.
- `BUNDLE_PATH=/tmp/posthog-ruby-bundle bundle exec rake public_api:check` - passed.
- `git diff --check origin/main...HEAD` - passed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a patch changeset for `posthog-ruby`.

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent (`worker`) prepared the existing implementation for review and opened this PR using the PR and autoreview skills. The local Pi session has no shareable URL. The agent added the required patch changeset, reran the Ruby validation, and reviewed the committed branch against `origin/main`. No review findings required code changes.
