### PR TITLE
fix(flags): align presence operator semantics

### DIFF
--- a/.changeset/local-properties-align.md
+++ b/.changeset/local-properties-align.md
@@ -1,5 +1,6 @@
 ---
 "posthog-ruby": patch
+"posthog-rails": patch
 ---
 
 Align local `is_set` and `is_not_set` evaluation with partial property context.

--- a/.changeset/local-properties-align.md
+++ b/.changeset/local-properties-align.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": patch
+---
+
+Align local `is_set` and `is_not_set` evaluation with partial property context.

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -614,7 +614,6 @@ module PostHog
 
     def self.match_property(property, property_values, cohort_properties = {})
       # only looks for matches where key exists in property_values
-      # doesn't support operator is_not_set
 
       PostHog::Utils.symbolize_keys! property
       PostHog::Utils.symbolize_keys! property_values
@@ -629,7 +628,7 @@ module PostHog
       if !property_values.key?(key)
         raise InconclusiveMatchError, "Property #{key} not found in property_values"
       elsif operator == 'is_not_set'
-        raise InconclusiveMatchError, 'Operator is_not_set not supported'
+        return false
       end
 
       override_value = property_values[key]

--- a/spec/posthog/feature_flag_spec.rb
+++ b/spec/posthog/feature_flag_spec.rb
@@ -1439,12 +1439,29 @@ module PostHog
 
       expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value' })).to be true
       expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 'value2' })).to be true
-      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '' })).to be true
       expect(FeatureFlagsPoller.match_property(property_a, { 'key' => nil })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => false })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 0 })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '' })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => [] })).to be true
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => {} })).to be true
 
       expect do
         FeatureFlagsPoller.match_property(property_a, { 'key2' => 'value' })
       end.to raise_error(InconclusiveMatchError)
+      expect { FeatureFlagsPoller.match_property(property_a, {}) }.to raise_error(InconclusiveMatchError)
+    end
+
+    it 'with operator is_not_set' do
+      property_a = { 'key' => 'key', 'value' => 'is_not_set', 'operator' => 'is_not_set' }
+
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => nil })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => false })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => 0 })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => '' })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => [] })).to be false
+      expect(FeatureFlagsPoller.match_property(property_a, { 'key' => {} })).to be false
+
       expect { FeatureFlagsPoller.match_property(property_a, {}) }.to raise_error(InconclusiveMatchError)
     end
 


### PR DESCRIPTION
## :bulb: Motivation and Context

[sdk-specs PR #49](https://github.com/PostHog/sdk-specs/pull/49) defines `is_not_set` using partial property context. The Ruby local evaluator raised an inconclusive error even when the caller supplied the property key.

This change returns false for `is_not_set` whenever the key is present, including nil and other falsey values. An omitted key remains inconclusive.

## :green_heart: How did you test it?

- Ruby syntax checks for the implementation and spec
- Direct smoke checks for present and omitted property behavior
- `pnpm changeset status` (patches `posthog-ruby` and `posthog-rails`)
- Autoreview completed on commit `39e05e1` with no actionable findings.

RSpec was not run locally because bundled dependencies were unavailable. CI will run the complete test suite.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent worker subagents implemented the focused matcher change and regression specs. The bundled autoreview tool reviewed the final committed diff against `origin/main`.
