### PR TITLE
fix: reset flag-called tracking when definitions reload

### DIFF
--- a/.changeset/fresh-flag-reload-tracking.md
+++ b/.changeset/fresh-flag-reload-tracking.md
@@ -1,5 +1,6 @@
 ---
 "posthog-ruby": patch
+"posthog-rails": patch
 ---
 
 Reset feature flag event deduplication when local flag definitions are refreshed or discarded, allowing the next flag access to emit a fresh event.

--- a/.changeset/fresh-flag-reload-tracking.md
+++ b/.changeset/fresh-flag-reload-tracking.md
@@ -1,0 +1,5 @@
+---
+"posthog-ruby": patch
+---
+
+Reset feature flag event deduplication when local flag definitions are refreshed or discarded, allowing the next flag access to emit a fresh event.

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -210,11 +210,8 @@ module PostHog
             feature_flag_request_max_retries: opts[:feature_flag_request_max_retries],
             async_load: opts[:feature_flags_async_load] == true,
             user_agent: @headers['User-Agent'],
-            on_flag_definitions_updated: lambda {
-              @distinct_id_has_sent_flag_calls_mutex.synchronize do
-                @distinct_id_has_sent_flag_calls.clear
-              end
-            }
+            flag_definitions_update_mutex: @distinct_id_has_sent_flag_calls_mutex,
+            on_flag_definitions_updated: -> { @distinct_id_has_sent_flag_calls.clear }
           )
       end
 

--- a/lib/posthog/client.rb
+++ b/lib/posthog/client.rb
@@ -191,6 +191,12 @@ module PostHog
         end
       end
 
+      # Initialize tracking before the poller can load definitions (including async loads).
+      @distinct_id_has_sent_flag_calls_mutex = Mutex.new
+      @distinct_id_has_sent_flag_calls = SizeLimitedHash.new(Defaults::MAX_HASH_SIZE) do |hash, key|
+        hash[key] = SizeLimitedArray.new(Defaults::MAX_HASH_SIZE)
+      end
+
       unless @disabled
         @feature_flags_poller =
           FeatureFlagsPoller.new(
@@ -203,13 +209,13 @@ module PostHog
             flag_definition_cache_provider: opts[:flag_definition_cache_provider],
             feature_flag_request_max_retries: opts[:feature_flag_request_max_retries],
             async_load: opts[:feature_flags_async_load] == true,
-            user_agent: @headers['User-Agent']
+            user_agent: @headers['User-Agent'],
+            on_flag_definitions_updated: lambda {
+              @distinct_id_has_sent_flag_calls_mutex.synchronize do
+                @distinct_id_has_sent_flag_calls.clear
+              end
+            }
           )
-      end
-
-      @distinct_id_has_sent_flag_calls_mutex = Mutex.new
-      @distinct_id_has_sent_flag_calls = SizeLimitedHash.new(Defaults::MAX_HASH_SIZE) do |hash, key|
-        hash[key] = SizeLimitedArray.new(Defaults::MAX_HASH_SIZE)
       end
 
       @before_send = opts[:before_send]

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -45,7 +45,9 @@ module PostHog
     #   immediate first tick at construction, then the regular polling cadence, which keeps retrying until a
     #   load succeeds.
     # @param user_agent [String] User-Agent header sent with feature flag requests.
-    # @param on_flag_definitions_updated [Proc, nil] Internal callback after definitions are applied or discarded.
+    # @param flag_definitions_update_mutex [Mutex] Internal lock shared with flag-called deduplication.
+    # @param on_flag_definitions_updated [Proc, nil] Internal callback after definitions are applied or discarded,
+    #   called while holding flag_definitions_update_mutex.
     def initialize(
       polling_interval,
       secret_key,
@@ -57,7 +59,8 @@ module PostHog
       feature_flag_request_max_retries: nil,
       async_load: false,
       user_agent: "posthog-ruby/#{PostHog::VERSION}",
-      on_flag_definitions_updated: nil
+      on_flag_definitions_updated: nil,
+      flag_definitions_update_mutex: Mutex.new
     )
       @polling_interval = polling_interval || Defaults::FeatureFlags::POLLING_INTERVAL_SECONDS
       @secret_key = secret_key
@@ -78,6 +81,7 @@ module PostHog
       @async_load = async_load
       @user_agent = user_agent
       @on_flag_definitions_updated = on_flag_definitions_updated
+      @flag_definitions_update_mutex = flag_definitions_update_mutex
       # Server-controlled gate for minimal `$feature_flag_called` events, read
       # from the top-level `minimal_flag_called_events` key of the local
       # evaluation definitions payload. false when the server does not send it.
@@ -1220,20 +1224,22 @@ module PostHog
 
       # Handle quota limits with 402 status
       if res.is_a?(Hash) && res[:status] == 402
-        definitions_were_loaded = definitions_loaded?
         logger.warn(
           '[FEATURE FLAGS] Feature flags quota limit exceeded - unsetting all local flags. ' \
           'Learn more about billing limits at https://posthog.com/docs/billing/limits-alerts'
         )
-        @feature_flags = Concurrent::Array.new
-        @feature_flags_by_key = {}
-        @group_type_mapping = Concurrent::Hash.new
-        @cohorts = Concurrent::Hash.new
-        @flag_definitions_loaded_at.value = nil
-        @minimal_flag_called_events = false
-        @loaded_flags_successfully_once.make_false
-        @quota_limited.make_true
-        @on_flag_definitions_updated&.call if definitions_were_loaded
+        @flag_definitions_update_mutex.synchronize do
+          definitions_were_loaded = definitions_loaded?
+          @feature_flags = Concurrent::Array.new
+          @feature_flags_by_key = {}
+          @group_type_mapping = Concurrent::Hash.new
+          @cohorts = Concurrent::Hash.new
+          @flag_definitions_loaded_at.value = nil
+          @minimal_flag_called_events = false
+          @loaded_flags_successfully_once.make_false
+          @quota_limited.make_true
+          @on_flag_definitions_updated&.call if definitions_were_loaded
+        end
         return
       end
 
@@ -1270,22 +1276,26 @@ module PostHog
       cohorts = get_by_symbol_or_string_key(data, 'cohorts') || {}
       minimal_flag_called_events = get_by_symbol_or_string_key(data, 'minimal_flag_called_events')
 
-      @feature_flags = Concurrent::Array.new(flags.map { |f| deep_symbolize_keys(f) })
-
+      new_flags = Concurrent::Array.new(flags.map { |f| deep_symbolize_keys(f) })
       new_by_key = {}
-      @feature_flags.each do |flag|
+      new_flags.each do |flag|
         new_by_key[flag[:key]] = flag unless flag[:key].nil?
       end
-      @feature_flags_by_key = new_by_key
+      new_group_type_mapping = Concurrent::Hash[deep_symbolize_keys(group_type_mapping)]
+      new_cohorts = Concurrent::Hash[deep_symbolize_keys(cohorts)]
 
-      @group_type_mapping = Concurrent::Hash[deep_symbolize_keys(group_type_mapping)]
-      @cohorts = Concurrent::Hash[deep_symbolize_keys(cohorts)]
-      @minimal_flag_called_events = minimal_flag_called_events == true
-
-      logger.debug "Loaded #{@feature_flags.length} feature flags and #{@cohorts.length} cohorts"
-      @flag_definitions_loaded_at.value = (Time.now.to_f * 1000).to_i
-      @loaded_flags_successfully_once.make_true if @loaded_flags_successfully_once.false?
-      @on_flag_definitions_updated&.call
+      # A read of the new definitions must not record its event before the tracker reset.
+      @flag_definitions_update_mutex.synchronize do
+        @feature_flags = new_flags
+        @feature_flags_by_key = new_by_key
+        @group_type_mapping = new_group_type_mapping
+        @cohorts = new_cohorts
+        @minimal_flag_called_events = minimal_flag_called_events == true
+        @flag_definitions_loaded_at.value = (Time.now.to_f * 1000).to_i
+        @loaded_flags_successfully_once.make_true if @loaded_flags_successfully_once.false?
+        @on_flag_definitions_updated&.call
+      end
+      logger.debug "Loaded #{new_flags.length} feature flags and #{new_cohorts.length} cohorts"
     end
 
     def _request_feature_flag_definitions(etag: nil)

--- a/lib/posthog/feature_flags.rb
+++ b/lib/posthog/feature_flags.rb
@@ -45,6 +45,7 @@ module PostHog
     #   immediate first tick at construction, then the regular polling cadence, which keeps retrying until a
     #   load succeeds.
     # @param user_agent [String] User-Agent header sent with feature flag requests.
+    # @param on_flag_definitions_updated [Proc, nil] Internal callback after definitions are applied or discarded.
     def initialize(
       polling_interval,
       secret_key,
@@ -55,7 +56,8 @@ module PostHog
       flag_definition_cache_provider: nil,
       feature_flag_request_max_retries: nil,
       async_load: false,
-      user_agent: "posthog-ruby/#{PostHog::VERSION}"
+      user_agent: "posthog-ruby/#{PostHog::VERSION}",
+      on_flag_definitions_updated: nil
     )
       @polling_interval = polling_interval || Defaults::FeatureFlags::POLLING_INTERVAL_SECONDS
       @secret_key = secret_key
@@ -75,6 +77,7 @@ module PostHog
       @flag_definitions_loaded_at = Concurrent::AtomicReference.new(nil)
       @async_load = async_load
       @user_agent = user_agent
+      @on_flag_definitions_updated = on_flag_definitions_updated
       # Server-controlled gate for minimal `$feature_flag_called` events, read
       # from the top-level `minimal_flag_called_events` key of the local
       # evaluation definitions payload. false when the server does not send it.
@@ -1217,6 +1220,7 @@ module PostHog
 
       # Handle quota limits with 402 status
       if res.is_a?(Hash) && res[:status] == 402
+        definitions_were_loaded = definitions_loaded?
         logger.warn(
           '[FEATURE FLAGS] Feature flags quota limit exceeded - unsetting all local flags. ' \
           'Learn more about billing limits at https://posthog.com/docs/billing/limits-alerts'
@@ -1229,6 +1233,7 @@ module PostHog
         @minimal_flag_called_events = false
         @loaded_flags_successfully_once.make_false
         @quota_limited.make_true
+        @on_flag_definitions_updated&.call if definitions_were_loaded
         return
       end
 
@@ -1280,6 +1285,7 @@ module PostHog
       logger.debug "Loaded #{@feature_flags.length} feature flags and #{@cohorts.length} cohorts"
       @flag_definitions_loaded_at.value = (Time.now.to_f * 1000).to_i
       @loaded_flags_successfully_once.make_true if @loaded_flags_successfully_once.false?
+      @on_flag_definitions_updated&.call
     end
 
     def _request_feature_flag_definitions(etag: nil)

--- a/spec/posthog/feature_flag_called_reload_spec.rb
+++ b/spec/posthog/feature_flag_called_reload_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'timeout'
 
 module PostHog
   describe 'feature flag called tracking across definition reloads' do
@@ -182,6 +183,73 @@ module PostHog
       client.reload_feature_flags
 
       expect(tracker).to have_received(:clear).once
+    end
+
+    %i[network cache quota].each do |source|
+      %i[single_flag snapshot].each do |access_path|
+        it "does not erase a concurrent #{access_path} access during a #{source} refresh" do
+          provider = double(
+            'cache provider',
+            should_fetch_flag_definitions?: true,
+            on_flag_definitions_received: nil,
+            shutdown: nil,
+            flag_definitions: { flags: [flag_definition.merge(active: false)] }
+          )
+          build_client(flag_definition_cache_provider: source == :cache ? provider : nil)
+          access = lambda {
+            if access_path == :snapshot
+              client.evaluate_flags('user', only_evaluate_locally: true).get_flag('beta-feature')
+            else
+              read_flag
+            end
+          }
+          expect(access.call).to be(true)
+          expect_single_event
+
+          if source == :cache
+            allow(provider).to receive(:should_fetch_flag_definitions?).and_return(false)
+          else
+            response = if source == :quota
+                         { status: 402, body: '{}' }
+                       else
+                         { status: 200, body: { flags: [flag_definition.merge(active: false)] }.to_json }
+                       end
+            stub_request(:get, definitions_endpoint).to_return(response)
+          end
+
+          start_refresh = Queue.new
+          reset_started = Queue.new
+          resume_reset = Queue.new
+          refresh = nil
+          mutex = client.instance_variable_get(:@distinct_id_has_sent_flag_calls_mutex)
+          allow(mutex).to receive(:synchronize).and_wrap_original do |synchronize, &block|
+            if Thread.current == refresh
+              reset_started << true
+              resume_reset.pop
+            end
+            synchronize.call(&block)
+          end
+          refresh = Thread.new do
+            start_refresh.pop
+            client.reload_feature_flags
+          end
+          start_refresh << true
+          Timeout.timeout(2) { reset_started.pop }
+
+          # Read while the refresh is about to acquire the deduplication lock.
+          # Either definition set is acceptable, but a new-set access must not be erased.
+          access.call
+          resume_reset << true
+          expect(refresh.join(2)).to eq(refresh)
+          refresh.value
+          2.times { expect(access.call).to eq(source == :quota ? nil : false) }
+          expect_single_event
+        ensure
+          resume_reset&.push(true)
+          refresh&.kill if refresh&.alive?
+          refresh&.join
+        end
+      end
     end
 
     it 'continues suppressing concurrent duplicate reads after reload' do

--- a/spec/posthog/feature_flag_called_reload_spec.rb
+++ b/spec/posthog/feature_flag_called_reload_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module PostHog
+  describe 'feature flag called tracking across definition reloads' do
+    let(:definitions_endpoint) { 'https://us.i.posthog.com/flags/definitions?token=testsecret&send_cohorts=true' }
+    let(:flag_definition) do
+      {
+        id: 1,
+        key: 'beta-feature',
+        active: true,
+        version: 1,
+        filters: { groups: [{ properties: [], rollout_percentage: 100 }] }
+      }
+    end
+    let(:definitions) { { flags: [flag_definition] } }
+    let(:client) { @client || build_client }
+    let(:poller) { client.instance_variable_get(:@feature_flags_poller) }
+
+    before do
+      stub_request(:get, definitions_endpoint).to_return(status: 200, body: definitions.to_json)
+    end
+
+    after { @client&.shutdown }
+
+    def build_client(**opts)
+      @client = Client.new(
+        api_key: API_KEY,
+        secret_key: API_KEY,
+        test_mode: true,
+        feature_flag_request_max_retries: 0,
+        **opts
+      )
+    end
+
+    def read_flag
+      client.get_feature_flag('beta-feature', 'user', only_evaluate_locally: true)
+    end
+
+    def expect_single_event
+      expect(client.queued_messages).to eq(1)
+      expect(client.dequeue_last_message[:event]).to eq('$feature_flag_called')
+    end
+
+    it 'emits once per user and flag response between successful manual reloads' do
+      2.times { expect(read_flag).to be(true) }
+      expect_single_event
+
+      client.reload_feature_flags
+
+      2.times { expect(read_flag).to be(true) }
+      expect_single_event
+    end
+
+    it 'resets the shared tracker for both snapshot and single-flag access' do
+      snapshot = client.evaluate_flags('user', only_evaluate_locally: true)
+      expect(snapshot.get_flag('beta-feature')).to be(true)
+      expect(read_flag).to be(true)
+      expect_single_event
+
+      client.reload_feature_flags
+
+      expect(snapshot.get_flag('beta-feature')).to be(true)
+      expect(read_flag).to be(true)
+      expect_single_event
+    end
+
+    it 'resets tracking on an automatic background refresh' do
+      refresh_allowed = Queue.new
+      requests = Concurrent::AtomicFixnum.new(0)
+      stub_request(:get, definitions_endpoint).to_return do
+        case requests.increment
+        when 1
+          { status: 200, body: definitions.to_json }
+        when 2
+          refresh_allowed.pop
+          { status: 200, body: { flags: [flag_definition.merge(version: 2)] }.to_json }
+        else
+          { status: 304, body: '' }
+        end
+      end
+      build_client(feature_flags_polling_interval: 0.1)
+      2.times { expect(read_flag).to be(true) }
+      expect_single_event
+
+      refresh_allowed << true
+
+      eventually do
+        expect(read_flag).to be(true)
+        expect(client.queued_messages).to eq(1)
+      end
+      expect_single_event
+      expect(poller.feature_flags_by_key['beta-feature'][:version]).to eq(2)
+      2.times { expect(read_flag).to be(true) }
+      expect(client.queued_messages).to eq(0)
+    ensure
+      refresh_allowed&.push(true)
+    end
+
+    it 'resets tracking when definitions are applied from the external cache' do
+      provider = double(
+        'cache provider',
+        should_fetch_flag_definitions?: true,
+        on_flag_definitions_received: nil,
+        shutdown: nil,
+        flag_definitions: definitions
+      )
+      build_client(flag_definition_cache_provider: provider)
+      2.times { expect(read_flag).to be(true) }
+      expect_single_event
+      allow(provider).to receive(:should_fetch_flag_definitions?).and_return(false)
+
+      poller._load_feature_flags
+
+      2.times { expect(read_flag).to be(true) }
+      expect_single_event
+      expect(WebMock).to have_requested(:get, definitions_endpoint).once
+    end
+
+    it 'resets tracking when an empty definitions response is applied' do
+      2.times { client.get_feature_flag('missing', 'user', only_evaluate_locally: true) }
+      expect_single_event
+      stub_request(:get, definitions_endpoint).to_return(status: 200, body: { flags: [] }.to_json)
+
+      client.reload_feature_flags
+
+      2.times { client.get_feature_flag('missing', 'user', only_evaluate_locally: true) }
+      expect_single_event
+    end
+
+    it 'resets tracking when a quota-limited response discards definitions' do
+      2.times { client.get_feature_flag('missing', 'user', only_evaluate_locally: true) }
+      expect_single_event
+      stub_request(:get, definitions_endpoint).to_return(status: 402, body: '{}')
+
+      client.reload_feature_flags
+
+      expect(client.feature_flags_loaded?).to be(false)
+      2.times { client.get_feature_flag('missing', 'user', only_evaluate_locally: true) }
+      expect_single_event
+    end
+
+    [
+      { status: 304, body: '' },
+      { status: 500, body: '{}' },
+      { status: 200, body: '{}' },
+      { status: 200, body: 'invalid json' }
+    ].each do |response|
+      it "preserves tracking when no definitions are applied (#{response})" do
+        2.times { expect(read_flag).to be(true) }
+        expect_single_event
+        stub_request(:get, definitions_endpoint).to_return(response)
+
+        client.reload_feature_flags
+
+        2.times { expect(read_flag).to be(true) }
+        expect(client.queued_messages).to eq(0)
+      end
+    end
+
+    it 'preserves tracking when the reload request times out' do
+      expect(read_flag).to be(true)
+      expect_single_event
+      stub_request(:get, definitions_endpoint).to_timeout
+
+      client.reload_feature_flags
+
+      expect(read_flag).to be(true)
+      expect(client.queued_messages).to eq(0)
+    end
+
+    it 'clears tracking under the same mutex used to suppress duplicates' do
+      expect(read_flag).to be(true)
+      tracker = client.instance_variable_get(:@distinct_id_has_sent_flag_calls)
+      mutex = client.instance_variable_get(:@distinct_id_has_sent_flag_calls_mutex)
+      allow(tracker).to receive(:clear).and_wrap_original do |clear|
+        expect(mutex.owned?).to be(true)
+        clear.call
+      end
+
+      client.reload_feature_flags
+
+      expect(tracker).to have_received(:clear).once
+    end
+
+    it 'continues suppressing concurrent duplicate reads after reload' do
+      expect(read_flag).to be(true)
+      expect_single_event
+      client.reload_feature_flags
+      start = Queue.new
+      threads = Array.new(4) do
+        Thread.new do
+          start.pop
+          5.times { read_flag }
+        end
+      end
+      threads.length.times { start << true }
+      threads.each do |thread|
+        expect(thread.join(2)).to eq(thread)
+        thread.value
+      end
+
+      expect_single_event
+    ensure
+      threads&.each { |thread| thread.kill if thread.alive? }
+    end
+  end
+end


### PR DESCRIPTION
## :bulb: Motivation and Context

Related to #189.

After local flag definitions reload, the client still remembers earlier `$feature_flag_called` events and suppresses the next access. Clear the existing tracker when definitions are applied or when a quota response discards loaded definitions. Manual reloads, background polling, and external-cache refreshes use the same callback.

Definition publication and tracker reset now share the existing deduplication mutex, closing the race where a refresh erased an event recorded against newly published definitions. Network requests, cache-provider callbacks, and logging stay outside that lock. Repeated reads between reloads remain deduplicated. HTTP 304 responses, failed requests, and responses without definitions leave tracking unchanged. Evaluations already in flight may still complete using definitions they read before a refresh.

## :green_heart: How did you test it?

- Added 13 regression examples that inspect queued events, covering manual and background reloads, external-cache refreshes, empty definitions, quota discard, shared snapshot tracking, failure preservation, and concurrent duplicate reads.
- Reproduction against the unchanged base failed 8 of those 13 examples. All 13 pass with this fix. Ten seeded regression runs also passed during implementation.
- Added six deterministic concurrency cases spanning network refreshes, external-cache refreshes, and quota clearing through both single-flag and snapshot access. All six reproduced duplicate events before the follow-up fix (expected one event, got two), and pass afterward.
- Re-ran `bundle exec rspec`: 696 examples, 0 failures. The 19-example reload suite also passed ten seeded runs (190 examples).
- Re-ran `bundle exec rubocop` (85 files), `bundle exec rake public_api:check`, and the core gem build. All passed. The gem build retains its existing missing-author warning.
- Original branch autoreview passed for `4f4b1de269fc651c7a79a1ba0f09d4ed0c90bf96`. Local autoreview of the concurrency follow-up, published as `d0b0315e801c64c409e38c3555619950e8f6eb74`, also passed with no actionable findings.

Validation used Ruby 4.0.6 and Bundler 4.0.13 with frozen dependencies. The CI Ruby 3.2/3.3/3.4 matrix was not run locally. Tests use WebMock rather than a live PostHog service.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. No documentation change was needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

The changeset selects patch releases for both `posthog-ruby` and `posthog-rails`. Rails delegates feature-flag access to the core client and pins the exact core SDK version, so it needs a release to receive this fix. The changeset was edited directly; the generator was not run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi agents implemented and independently reviewed this user-directed fix. Tools used were Git, Bundler/RSpec, RuboCop, Rake, RubyGems, GitHub CLI, and the isolated Pi autoreview helper. Session references: implementation `3efed453-bba9-4ebc-853b-b7247693a8d8`, publication `510ebebc-a750-45a5-88ce-92821ccd3256` (local sessions, no public link).

The fix keeps the existing bounded tracker and mutex rather than adding generation tracking or changing the public client API. Human review is required before merging.
